### PR TITLE
Add data-player-type attribute in soundcloud snippet in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,8 @@ Example of Soundcloud API and `iframe` embed:
 ```html
 <script src="https://w.soundcloud.com/player/api.js"></script>
 <iframe
-  id="so"
+  id="hyperplayer"
+  data-player-type="soundcloud"
   width="100%"
   height="166"
   scrolling="no"


### PR DESCRIPTION
This is a minor tweak to the documentation.

I made a small demo using the soundcloud player, and it wouldn't play at first. When I compared the multiplayer example in this repo to the snippet, I noticed that the `data-player-type` attribute wasn't included in the docs.

This adds the attribute to the snippet in the README.

(I also updated the ID of the iframe to match the ID in the javascript snippet, just for copy/paste convenience. Let me know if you want me to revert that)