### PR TITLE
Set currentTime after audio is loaded.

### DIFF
--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -115,7 +115,9 @@ class HyperaudioLite {
 
     if (!isNaN(parseFloat(start))) {
       if (this.playerType === 'native') {
-        this.player.currentTime = start;
+        this.player.addEventListener('loadeddata', function(){
+          this.currentTime = start;
+        })    
         //autoplay
         const promise = this.player.play();
         if (promise !== undefined) {


### PR DESCRIPTION
In Safari and iOS the currentTime can only be set after the audio is partially loaded. This change makes sure some of the audio is loaded before trying to set the currentTime.