### PR TITLE
Add 'active' class without replacing all existing classes.

### DIFF
--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -256,7 +256,7 @@ class HyperaudioLite {
       e.classList.remove('active');
     });
 
-    target.setAttribute('class', 'active');
+    target.classList.add('active');
 
     const timeSecs = parseInt(target.getAttribute('data-m')) / 1000;
 


### PR DESCRIPTION
The current `setAttribute('class', 'active')` is removing all existing classes on that element, which is sometimes causing some strange styling behaviour. By using `classList.add('active')` we only add the active class, but keep all existing classes in place.