### PR TITLE
44 yt karaoke fix

### DIFF
--- a/__TEST__/hyperaudio-lite.test.js
+++ b/__TEST__/hyperaudio-lite.test.js
@@ -1,5 +1,7 @@
 /**
  * @jest-environment jsdom
+ * 
+ * Tests updated for version 2.0.8
  */
 
 const { test } = require("@jest/globals");
@@ -104,7 +106,7 @@ test("updateTranscriptVisualState", () => {
 
   ht.currentTime = 8.106641;
 
-  expect(ht.updateTranscriptVisualState()).toStrictEqual(expectedResult);
+  expect(ht.updateTranscriptVisualState(ht.currentTime)).toStrictEqual(expectedResult);
 });
 
 test("media playback - click on word", () => {

--- a/youtube.html
+++ b/youtube.html
@@ -1,10 +1,10 @@
-<!-- Version 2.0.6 -->
+<!-- Version 2.0.8 -->
 
 <!DOCTYPE html>
 <html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <title>Connect with SoundCloud</title>
+    <title>YouTube Version</title>
     <link rel="stylesheet" href="css/hyperaudio-lite-player.css">
     <link rel="stylesheet" href="css/share-this.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.5.0/velocity.js"></script>


### PR DESCRIPTION
Addresses https://github.com/hyperaudio/hyperaudio-lite/issues/44 also for SoundCloud and native media, where a page is loaded with start and end parameters from a sharing URL - eg `/hyperaudio-lite/#hypertranscript=91.7,94`

Now, pressing play on the media player should jump directly to the highlighted text and play it – with the karaoke effect intact.