### PR TITLE
Changed substr to substring #96

### DIFF
--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -14,7 +14,7 @@ class HyperaudioLite {
     const hashVar = windowHash.substring(1, windowHash.indexOf('='));
 
     if (hashVar === this.transcript.id) {
-      this.hashArray = windowHash.substr(this.transcript.id.length + 2).split(',');
+      this.hashArray = windowHash.substring(this.transcript.id.length + 2).split(',');
     } else {
       this.hashArray = [];
     }


### PR DESCRIPTION
There was only one instance of `substr` in the repo. :)

[`substr` is indeed deprecated](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) and [`substring` does the same job](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring).