### PR TITLE
209 remove velocity

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,14 +127,13 @@ and the associated CSS files:
 
 3. `hyperaudio-lite-player.css`
 
-We also link to [Velocity 1.5](https://github.com/julianshapiro/velocity) for autoscroll.
+Autoscroll uses the browser's native smooth scrolling.
 
 Add to your HTML file in the following way:
 
 ```HTML
 <head>
   <link rel="stylesheet" href="css/hyperaudio-lite-player.css">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.5.0/velocity.js"></script>
 </head>
 ```
 

--- a/active.html
+++ b/active.html
@@ -6,7 +6,6 @@
   <meta charset="utf-8">
   <title>Hyperaudio - BBCRD | Education | Ethics of personal data in the era of QS and IoT</title>
   <link rel="stylesheet" href="css/hyperaudio-lite-player.css">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.5.0/velocity.js"></script>
   <style>
     /* uncomment the following CSS for active parent / word indicator */ 
     

--- a/active.html
+++ b/active.html
@@ -1,5 +1,5 @@
 <!-- Example index.html Copyright (C) BBC Research & Development - content used with kind permission of Ian Forrester https://twitter.com/cubicgarden/ -->
-<!-- Version 2.1 -->
+<!-- Version 2.4.0 -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# Version 2.4.0
+
+- Removed `velocity.js` dependency
+- Autoscroll now uses a native `requestAnimationFrame` animation with `easeInOutCubic` easing
+- Active paragraph scrolls to the top of the transcript viewport
+
 # Version 2.0.0
 
 - Object based approach to prevent scope leak

--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
   <meta charset="utf-8">
   <title>Hyperaudio - BBCRD | Education | Ethics of personal data in the era of QS and IoT</title>
   <link rel="stylesheet" href="css/hyperaudio-lite-player.css">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.5.0/velocity.js"></script>
   <style>
     /* uncomment the following CSS for active parent / word indicator */ 
     

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!-- Example index.html Copyright (C) BBC Research & Development - content used with kind permission of Ian Forrester https://twitter.com/cubicgarden/ -->
-<!-- Version 2.2.0 -->
+<!-- Version 2.4.0 -->
 
 <!DOCTYPE html>
 <html>

--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -1,5 +1,5 @@
 /*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
-/*! Version 2.3.2 */
+/*! Version 2.3.3 */
 
 'use strict';
 
@@ -309,7 +309,6 @@ class HyperaudioLite {
     this.minimizedMode = minimizedMode;
     this.autoscroll = autoscroll;
     this.webMonetization = webMonetization;
-    this.scrollerContainer = this.transcript;
   }
 
   // Setup hash for transcript selection
@@ -407,13 +406,8 @@ class HyperaudioLite {
   }
 
   setupAutoScroll(autoscroll) {
-    if (autoscroll) {
-      if (window.Velocity) {
-        this.scroller = window.Velocity;
-      } else if (window.jQuery && window.jQuery.Velocity) {
-          this.scroller = window.jQuery.Velocity;
-      }
-    }
+    this.autoscroll = autoscroll;
+    this.scrollContainer = this.transcript;
   }
 
   // Setup event listeners for interactions
@@ -608,28 +602,44 @@ class HyperaudioLite {
     }
   }
 
-  // Scroll to the paragraph containing the current word
   scrollToParagraph(currentParentElementIndex, index) {
-
-    const scrollNode = this.wordArr[index - 1].n.closest('p') || this.wordArr[index - 1].n;
-
     if (currentParentElementIndex !== this.parentElementIndex) {
-      if (this.autoscroll && typeof this.scroller !== 'undefined') {
-        if (scrollNode) {
-          this.scroller(scrollNode, 'scroll', {
-            container: this.scrollerContainer,
-            duration: this.scrollerDuration,
-            delay: this.scrollerDelay,
-            offset: this.scrollerOffset,
-          });
-        } else {
-          this.wordArr = this.createWordArray(this.transcript.querySelectorAll('[data-m]'));
-          this.parentElements = this.transcript.getElementsByTagName(this.parentTag);
+      if (this.autoscroll) {
+        const currentParagraph = this.parentElements[currentParentElementIndex];
+        if (currentParagraph) {
+          const containerRect = this.scrollContainer.getBoundingClientRect();
+          const paragraphRect = currentParagraph.getBoundingClientRect();
+          const targetTop = this.scrollContainer.scrollTop + (paragraphRect.top - containerRect.top);
+          this.smoothScrollTo(this.scrollContainer, targetTop, 800);
         }
       }
       this.parentElementIndex = currentParentElementIndex;
     }
   }
+
+  smoothScrollTo(container, targetTop, duration) {
+    if (this.scrollAnimationId) {
+      cancelAnimationFrame(this.scrollAnimationId);
+    }
+    const startTop = container.scrollTop;
+    const distance = targetTop - startTop;
+    if (distance === 0) return;
+    const startTime = performance.now();
+    const easeInOutCubic = t => t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+
+    const step = now => {
+      const elapsed = now - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+      container.scrollTop = startTop + distance * easeInOutCubic(progress);
+      if (progress < 1) {
+        this.scrollAnimationId = requestAnimationFrame(step);
+      } else {
+        this.scrollAnimationId = null;
+      }
+    };
+    this.scrollAnimationId = requestAnimationFrame(step);
+  }
+
 
   // Check the status of the playhead and update the transcript
   checkStatus() {

--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -1,5 +1,5 @@
 /*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
-/*! Version 2.3.3 */
+/*! Version 2.4.0 */
 
 'use strict';
 

--- a/multiplayer.html
+++ b/multiplayer.html
@@ -6,7 +6,6 @@
   <title>Multiplayer Test</title>
   <link rel="stylesheet" href="css/hyperaudio-lite-player.css">
   <link rel="stylesheet" href="css/share-this.css">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.5.0/velocity.js"></script>
   <script src="https://platform.twitter.com/widgets.js"></script>
   <style>
     #popover {

--- a/multiplayer.html
+++ b/multiplayer.html
@@ -1,4 +1,4 @@
-<!-- Version 2.0.0 -->
+<!-- Version 2.4.0 -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Hyperaudio-Lite",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Hyperaudio-Lite",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "license": "MIT",
   "devDependencies": {
     "jest": "^29.7.0",

--- a/soundcloud.html
+++ b/soundcloud.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>Connect with SoundCloud</title>
     <link rel="stylesheet" href="css/hyperaudio-lite-player.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.5.0/velocity.js"></script>
     <style>
       /* uncomment the following CSS for active parent / word indicator */ 
       

--- a/soundcloud.html
+++ b/soundcloud.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.1 -->
+<!-- Last updated for Version 2.4.0 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/spotify.html
+++ b/spotify.html
@@ -7,7 +7,6 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <title>Spotify Version</title>
   <link rel="stylesheet" href="css/hyperaudio-lite-player.css">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.5.0/velocity.js"></script>
   <style>
     /* uncomment the following CSS for active parent / word indicator */
 

--- a/spotify.html
+++ b/spotify.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.1.6 -->
+<!-- Last updated for Version 2.4.0 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/videojs.html
+++ b/videojs.html
@@ -8,7 +8,6 @@
   <title>Vimeo Version</title>
   <link rel="stylesheet" href="css/hyperaudio-lite-player.css">
   <link href="https://vjs.zencdn.net/7.4.1/video-js.css" rel="stylesheet" />
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.5.0/velocity.js"></script>
   <script src="https://vjs.zencdn.net/7.4.1/video.min.js"></script>
   <style>
     /* uncomment the following CSS for active parent / word indicator */ 

--- a/videojs.html
+++ b/videojs.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.1 -->
+<!-- Last updated for Version 2.4.0 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/vidstack.html
+++ b/vidstack.html
@@ -8,8 +8,6 @@
   <title>Vidstack Version</title>
   <link rel="stylesheet" href="css/hyperaudio-lite-player.css">
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.5.0/velocity.js"></script>
-
   <link rel="stylesheet" href="https://cdn.vidstack.io/player/theme.css" />
   <link rel="stylesheet" href="https://cdn.vidstack.io/player/video.css" />
   <script src="https://cdn.vidstack.io/player" type="module"></script>

--- a/vidstack.html
+++ b/vidstack.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.1 -->
+<!-- Last updated for Version 2.4.0 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/vimeo.html
+++ b/vimeo.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.1 -->
+<!-- Last updated for Version 2.4.0 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/vimeo.html
+++ b/vimeo.html
@@ -7,7 +7,6 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <title>Vimeo Version</title>
   <link rel="stylesheet" href="css/hyperaudio-lite-player.css">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.5.0/velocity.js"></script>
   <style>
     /* uncomment the following CSS for active parent / word indicator */ 
     

--- a/youtube-multiplayer.html
+++ b/youtube-multiplayer.html
@@ -1,4 +1,4 @@
-<!-- Version 2.0.11 -->
+<!-- Version 2.4.0 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/youtube-multiplayer.html
+++ b/youtube-multiplayer.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>YouTube Version</title>
     <link rel="stylesheet" href="css/hyperaudio-lite-player.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.5.0/velocity.js"></script>
     <style>
     #popover {
       position: absolute;

--- a/youtube.html
+++ b/youtube.html
@@ -6,7 +6,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>YouTube Version</title>
     <link rel="stylesheet" href="css/hyperaudio-lite-player.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.5.0/velocity.js"></script> 
   </head>
   <style>
     /* uncomment the following CSS for active parent / word indicator */ 

--- a/youtube.html
+++ b/youtube.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.0.22 -->
+<!-- Last updated for Version 2.4.0 -->
 
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
## Summary

  Removes the `velocity.js` runtime dependency and replaces it with a native, in-house
  smooth-scroll implementation. Hyperaudio Lite no longer pulls in a CDN dependency just to animate
   transcript autoscroll. Follow-up to PR #208 (which restored Velocity-based autoscroll after the
  v2.3 refactor accidentally dropped it). Bumps the library to version 2.4.0.

  ## What changed

  **Drop velocity.js**
  - Removed the `<script src=".../velocity/1.5.0/velocity.js">` tag from every example HTML
  (`index`, `active`, `soundcloud`, `spotify`, `vimeo`, `videojs`, `vidstack`, `youtube`,
  `youtube-multiplayer`, `multiplayer`).
  - Updated README to drop the Velocity link and script tag from the install snippet.

  **Rewrite `scrollToParagraph`**
  - New `smoothScrollTo` helper uses `requestAnimationFrame` with an `easeInOutCubic` curve over
  800ms — slower and more fluid than the native `scrollTo({behavior:'smooth'})` (~300ms,
  browser-controlled).
  - In-flight animations are cancelled when a new scroll is requested, so rapid paragraph changes
  don't fight each other.
  - Scroll target computed with `getBoundingClientRect` deltas (layout-agnostic, correct regardless
   of where the transcript sits on the page).
  - The active paragraph is pinned to the top of the scroll container's viewport.

  **Cleanup**
  - Removed `scroller`, `scrollerContainer`, `setupAutoScroll` Velocity wiring (added by #208).
  - Fixed a latent bug where `scrollContainer` was set to the transcript's parent element instead
  of the transcript itself (the transcript is what has `overflow-y: scroll` in every example).

  **Version bump to 2.4.0**
  - `package.json`, `package-lock.json`, the `Version` comment in `js/hyperaudio-lite.js`, the
  per-example HTML version markers, and a new entry in `changelog.md`.

  ## Browser compatibility

  Per caniuse:
  - `Element.scrollTop` write + `requestAnimationFrame`: ~99% global, works everywhere back to
  IE10.
  - This is actually **wider** support than `scrollTo({behavior:'smooth'})` (~95%, Safari only got
  smooth-scroll in 15.4 / March 2022).

  No regression vs the project's stated baseline — IE support was already dropped at v2.0.

  ## Test plan

  - [x] `npm test` — all 25 existing tests pass locally
  - [ ] Open `index.html` and confirm autoscroll feels smooth as the audio plays across paragraph
  boundaries
  - [ ] Verify the active paragraph lands at the top of the transcript viewport
  - [ ] Scrub via word-click and confirm scroll behaves on jumps
  - [ ] Spot-check on `youtube.html`, `soundcloud.html`, `vimeo.html`, `videojs.html`,
  `vidstack.html`, `spotify.html`, `multiplayer.html`
  - [ ] Verify no console errors (in particular, no "Velocity is not defined")