### PR TITLE
Modernize Web Monetization integration (resolves #215, #194)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,11 +280,15 @@ cap1.init("hypertranscript", "hyperplayer", '37' , '21'); // transcript Id, play
 
 ## :money_with_wings: Web Monetization Support :money_with_wings:
 
-[Web Monetization](https://webmonetization.org/) is a JavaScript browser API that allows the creation of a payment stream from the user agent to the website and a [proposed](https://discourse.wicg.io/t/proposal-web-monetization-a-new-revenue-model-for-the-web/3785) [W3C](https://www.w3.org/) standard.
+[Web Monetization](https://webmonetization.org/) is a browser API, stewarded by the [Interledger Foundation](https://interledger.org/), that lets visitors stream micropayments to the sites they're reading. There is currently no native browser support — visitors need a [Web Monetization agent](https://webmonetization.org/supporters/get-started/) (browser extension) installed to actually pay.
 
-You can use this with Hyperaudio Lite to apportion streaming funds (from viewers with Web Monetization compatible wallets and browser extensions) to different sources depending on the transcript or part of the transcript you are currently listening to.
+With Hyperaudio Lite you can apportion those streamed funds to different recipients depending on which transcript — or which part of the transcript — the viewer is currently listening to.
 
-To activate set the Web Monetization parameter when instantiating a new `HyperaudioLite` object to `true`, for example:
+See [`active.html`](./active.html) for a working example.
+
+### How to enable it
+
+Set the Web Monetization parameter to `true` when instantiating `HyperaudioLite`:
 
 ```javascript
 let minimizedMode = false;
@@ -296,16 +300,16 @@ let playOnClick = true;
 new HyperaudioLite("hypertranscript", "hyperplayer", minimizedMode, autoScroll, doubleClick, webMonetization, playOnClick);
 ```
 
-If you then set the `data-wm` attributes in your transcript streaming will be switched to that payment pointer when encountered.
+Then add `data-wm` attributes (containing wallet URLs) to elements in your transcript. As playback moves between elements, Hyperaudio Lite injects a `<link rel="monetization" href="...">` element into the page `<head>`, pointed at the currently active wallet URL.
 
 ```html
-   <article data-wm="$ilp.uphold.com/123article">
+   <article data-wm="https://ilp.uphold.com/123article">
 
-      <section data-wm="$ilp.uphold.com/123section">
+      <section data-wm="https://ilp.uphold.com/123section">
 
         <h5 data-m="0">How do we make people more aware of their personal data?</h5>
 
-        <p data-wm="$ilp.uphold.com/123Doc">
+        <p data-wm="https://ilp.uphold.com/123Doc">
           <span data-m="4470" data-d="0" class="speaker">Doc: </span>
           <span data-m="4470" data-d="270">We </span>
           <span data-m="4740" data-d="240">have </span>
@@ -314,7 +318,10 @@ If you then set the `data-wm` attributes in your transcript streaming will be sw
           ...
 ```
 
-*Note* – if a `data-wm` attribute is not present in an element Hyperaudio Lite will check the parent (and parent's parent etc) until it finds one. 
+*Note* – if a `data-wm` attribute is not present on an element, Hyperaudio Lite walks up to the parent (and the parent's parent, etc.) until it finds one.
+
+*Note* – the value of `data-wm` should be a full wallet URL (e.g. `https://ilp.uphold.com/...`), not the older `$`-prefixed payment-pointer shorthand. The shorthand form is no longer recognised by current Web Monetization agents.
+
 
 ## :construction_worker: Testing :construction_worker:
 

--- a/active.html
+++ b/active.html
@@ -87,13 +87,13 @@
 
   <div id="hypertranscript" class="hyperaudio-transcript" style="overflow-y:scroll; height:600px; position:relative; border-style:dashed; border-width: 1px; border-color:#999; padding: 8px">
     
-    <article data-wm="$ilp.uphold.com/123article">
+    <article data-wm="https://ilp.uphold.com/123article">
 
-      <section data-media-src="https://lab.hyperaud.io/video/BBC/education.mp4" data-media-type="audio/mp3" data-wm="$ilp.uphold.com/123section">
+      <section data-media-src="https://lab.hyperaud.io/video/BBC/education.mp4" data-media-type="audio/mp3" data-wm="https://ilp.uphold.com/123section">
 
         <h5 data-m="0">How do we make people more aware of their personal data?</h5>
 
-        <p data-wm="$ilp.uphold.com/123Doc">
+        <p data-wm="https://ilp.uphold.com/123Doc">
           <span data-m="4470" data-d="0" class="speaker">Doc: </span>
           <span data-m="4470" data-d="270">We </span>
           <span data-m="4740" data-d="240">have </span>
@@ -156,7 +156,7 @@
           <span data-m="26010" data-d="270">data </span>
           <span data-m="26280" data-d="440">space. </span>
         </p>
-        <p data-wm="$ilp.uphold.com/123Julian">
+        <p data-wm="https://ilp.uphold.com/123Julian">
           <span data-m="26940" data-d="0" class="speaker">Julian: </span>
           <span data-m="26940" data-d="240">We </span>
           <span data-m="27180" data-d="360">are </span>

--- a/index.html
+++ b/index.html
@@ -91,13 +91,13 @@
 
   <div id="hypertranscript" class="hyperaudio-transcript" style="overflow-y:scroll; height:600px; position:relative; border-style:dashed; border-width: 1px; border-color:#999; padding: 8px">
     
-    <article data-wm="$ilp.uphold.com/123article">
+    <article>
 
-      <section data-media-src="https://lab.hyperaud.io/video/BBC/education.mp4" data-wm="$ilp.uphold.com/123section">
+      <section data-media-src="https://lab.hyperaud.io/video/BBC/education.mp4">
 
         <h5 data-m="0">How do we make people more aware of their personal data?</h5>
 
-        <p data-wm="$ilp.uphold.com/123Doc">
+        <p>
           <span data-m="4470" data-d="0" class="speaker">Doc: </span>
           <span data-m="4470" data-d="270">We </span>
           <span data-m="4740" data-d="240">have </span>
@@ -160,7 +160,7 @@
           <span data-m="26010" data-d="270">data </span>
           <span data-m="26280" data-d="440">space. </span>
         </p>
-        <p data-wm="$ilp.uphold.com/123Julian">
+        <p>
           <span data-m="26940" data-d="0" class="speaker">Julian: </span>
           <span data-m="26940" data-d="240">We </span>
           <span data-m="27180" data-d="360">are </span>
@@ -1043,7 +1043,7 @@
   let minimizedMode = false;
   let autoScroll = true;
   let doubleClick = false;
-  let webMonetization = true;
+  let webMonetization = false;
   let playOnClick = false;
 
   new HyperaudioLite("hypertranscript", "hyperplayer", minimizedMode, autoScroll, doubleClick, webMonetization, playOnClick);

--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -673,21 +673,18 @@ class HyperaudioLite {
         }
 
         if (this.webMonetization === true) {
-          //check for payment pointer
           let activeElements = this.transcript.getElementsByClassName('active');
           let paymentPointer = this.checkPaymentPointer(activeElements[activeElements.length - 1]);
-    
+
           if (paymentPointer !== null) {
-            let metaElements = document.getElementsByTagName('meta');
-            let wmMeta = document.querySelector("meta[name='monetization']");
-            if (wmMeta === null) {
-              wmMeta = document.createElement('meta');
-              wmMeta.name = 'monetization';
-              wmMeta.content = paymentPointer;
-              document.getElementsByTagName('head')[0].appendChild(wmMeta);
+            let wmLink = document.querySelector("link[rel='monetization']");
+            if (wmLink === null) {
+              wmLink = document.createElement('link');
+              wmLink.rel = 'monetization';
+              wmLink.href = paymentPointer;
+              document.getElementsByTagName('head')[0].appendChild(wmLink);
             } else {
-              wmMeta.name = 'monetization';
-              wmMeta.content = paymentPointer;
+              wmLink.href = paymentPointer;
             }
           }
         }

--- a/videojs.html
+++ b/videojs.html
@@ -93,13 +93,13 @@
   <div id="hypertranscript" class="hyperaudio-transcript"
     style="overflow-y:scroll; height:600px; position:relative; border-style:dashed; border-width: 1px; border-color:#999; padding: 8px">
 
-    <article data-wm="$ilp.uphold.com/123article">
+    <article>
 
-      <section data-wm="$ilp.uphold.com/123section">
+      <section>
 
         <h5 data-m="0">How do we make people more aware of their personal data?</h5>
 
-        <p data-wm="$ilp.uphold.com/123Doc">
+        <p>
           <span data-m="4470" data-d="0" class="speaker">Doc: </span>
           <span data-m="4470" data-d="270">We </span>
           <span data-m="4740" data-d="240">have </span>
@@ -162,7 +162,7 @@
           <span data-m="26010" data-d="270">data </span>
           <span data-m="26280" data-d="440">space. </span>
         </p>
-        <p data-wm="$ilp.uphold.com/123Julian">
+        <p>
           <span data-m="26940" data-d="0" class="speaker">Julian: </span>
           <span data-m="26940" data-d="240">We </span>
           <span data-m="27180" data-d="360">are </span>

--- a/vidstack.html
+++ b/vidstack.html
@@ -83,13 +83,13 @@
   <div id="hypertranscript" class="hyperaudio-transcript"
     style="overflow-y:scroll; height:600px; position:relative; border-style:dashed; border-width: 1px; border-color:#999; padding: 8px">
 
-    <article data-wm="$ilp.uphold.com/123article">
+    <article>
 
-      <section data-wm="$ilp.uphold.com/123section">
+      <section>
 
         <h5 data-m="0">How do we make people more aware of their personal data?</h5>
 
-        <p data-wm="$ilp.uphold.com/123Doc">
+        <p>
           <span data-m="4470" data-d="0" class="speaker">Doc: </span>
           <span data-m="4470" data-d="270">We </span>
           <span data-m="4740" data-d="240">have </span>
@@ -152,7 +152,7 @@
           <span data-m="26010" data-d="270">data </span>
           <span data-m="26280" data-d="440">space. </span>
         </p>
-        <p data-wm="$ilp.uphold.com/123Julian">
+        <p>
           <span data-m="26940" data-d="0" class="speaker">Julian: </span>
           <span data-m="26940" data-d="240">We </span>
           <span data-m="27180" data-d="360">are </span>


### PR DESCRIPTION
The previous implementation injected <meta name="monetization" content="..."> tags using $-prefixed payment-pointer shorthand. Both the meta tag form and the shorthand syntax were deprecated by the Web Monetization spec in the 2023-09-20 draft, and Coil (the only widely-used WM agent that read them) shut down in March 2023. As a result, the feature was effectively dead in practice — no current Web Monetization agent reads what the code emits.

Changes:

- js/hyperaudio-lite.js now injects <link rel="monetization" href="..."> as required by the current Interledger Foundation spec.

- active.html keeps Web Monetization enabled and demonstrates the feature, with data-wm attributes updated to full wallet URLs (https://ilp.uphold.com/... rather than $ilp.uphold.com/...).

- index.html no longer enables Web Monetization and no longer carries data-wm attributes. Resolves #194.

- videojs.html and vidstack.html had dangling data-wm attributes even though their webMonetization flag was already false. Removed.

- README Web Monetization section updated: points readers at active.html as the example, explains the link-element approach, drops the obsolete payment-pointer shorthand from the snippet, and notes that visitors still need a Web Monetization browser extension since no browser ships native support.

All 25 existing tests pass.