### PR TITLE
Follow seeks (scrub-while-paused) and add pauseAutoscroll/resumeAutoscroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,19 @@ let playOnClick = true;
 new HyperaudioLite("hypertranscript", "hyperplayer", minimizedMode, autoScroll, doubleClick, webMonetization, playOnClick);
 ```
 
+### Autoscroll behaviour
+
+When `autoScroll` is enabled, the transcript follows playback and also follows seeks while paused — scrubbing the media (drag the seek bar, jump in the native controls, set `currentTime`) re-aligns the transcript's read/unread state and scroll position to the new playhead.
+
+To temporarily disable autoscroll (e.g. while a user is editing the transcript), call `pauseAutoscroll()` and re-enable it with `resumeAutoscroll()`:
+
+```javascript
+const player = new HyperaudioLite("hypertranscript", "hyperplayer", false, true, false, false, true);
+player.pauseAutoscroll();
+// ...later
+player.resumeAutoscroll();
+```
+
 If you want to use the native audio/video capabilities of your browser, you would define your player something like this:
 
 ```html

--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -22,6 +22,7 @@ class BasePlayer {
   attachEventListeners(instance) {
     this.player.addEventListener('pause', instance.pausePlayHead.bind(instance), false);
     this.player.addEventListener('play', instance.preparePlayHead.bind(instance), false);
+    this.player.addEventListener('seeked', instance.handleSeeked.bind(instance), false);
   }
 
   // Method to get the current time of the player
@@ -295,6 +296,7 @@ class HyperaudioLite {
     this.setPlayHead = this.setPlayHead.bind(this);
     this.checkPlayHead = this.checkPlayHead.bind(this);
     this.clearTimer = this.clearTimer.bind(this);
+    this.handleSeeked = this.handleSeeked.bind(this);
   }
 
   // Initialize the HyperaudioLite instance
@@ -577,6 +579,29 @@ class HyperaudioLite {
   pausePlayHead() {
     this.clearTimer();
     this.myPlayer.paused = true;
+  }
+
+  // Update transcript visual state + scroll position to match a seek (works while paused).
+  // Does not toggle the word-level `.active` class — `updateTranscriptVisualState`
+  // still defers that to the playing-state path.
+  handleSeeked() {
+    (async () => {
+      this.currentTime = await this.myPlayer.getTime();
+      const indices = this.updateTranscriptVisualState(this.currentTime);
+      if (indices.currentWordIndex > 0 && this.autoscroll) {
+        this.scrollToParagraph(indices.currentParentElementIndex, indices.currentWordIndex);
+      }
+    })();
+  }
+
+  // Temporarily disable autoscroll (e.g. while a user is editing the transcript).
+  pauseAutoscroll() {
+    this.autoscroll = false;
+  }
+
+  // Re-enable autoscroll after a pauseAutoscroll() call.
+  resumeAutoscroll() {
+    this.autoscroll = true;
   }
 
   // Check the playhead position and update the transcript


### PR DESCRIPTION
Resolves the core + pause-hook parts of #222. The `scrollContainer` constructor option is deferred to #217 (options-object refactor) where it belongs without further bloating the positional signature.

## Changes

### Core — follow seeks
`BasePlayer.attachEventListeners` now attaches a `seeked` listener that calls a new `HyperaudioLite.handleSeeked()` method. On every seek (including while paused) the transcript's read/unread visual state and scroll position re-align to the new playhead. The word-level `.active` class is **not** toggled here — that suppression-while-paused behaviour is tracked separately in #220.

This means scrubbing the media (drag the seek bar, jump in the native controls, set `currentTime` programmatically) now updates the transcript out of the box. Downstream consumers like the Hyperaudio Lite Editor that currently glue this themselves can drop their reimplementation.

The non-DOM player adapters (SoundCloud, YouTube, Vimeo, VideoJS) override `attachEventListeners`, so they're unaffected by this change. Adding seek-follow to each of those would be a sensible follow-up.

### Pause hook
Two thin documented helpers:

```javascript
player.pauseAutoscroll();   // e.g. while a user edits the transcript
player.resumeAutoscroll();
```

These wrap the existing `instance.autoscroll` boolean — no behaviour change, just a supported API instead of poking the field.

### scrollContainer (deferred)
Adding `scrollContainer` as an 8th positional constructor argument would push the signature further into "boolean parameter trap" territory. Better landed alongside the options-object refactor in #217 — added a note there.

## Compat

- **Seeked listener**: technically a behaviour change (scrub-while-paused now updates transcript instead of doing nothing), but the previous behaviour was the gap the issue is about. Consumers with their own glue will run twice harmlessly until they remove it.
- **Pause/resume helpers**: pure addition, zero risk.

## Test plan

- [x] `npm test` — all 25 Jest tests pass
- [ ] Manual: native `<video>` example — scrub while paused, confirm transcript scroll + read/unread state follow
- [ ] Manual: native `<video>` example — `pauseAutoscroll()` from console, scrub, confirm no scroll; `resumeAutoscroll()`, confirm scroll resumes