### PR TITLE
Highlight active word on scrub-while-paused (resolves #220)

### DIFF
--- a/active.html
+++ b/active.html
@@ -1,5 +1,5 @@
 <!-- Example index.html Copyright (C) BBC Research & Development - content used with kind permission of Ian Forrester https://twitter.com/cubicgarden/ -->
-<!-- Version 2.4.3 -->
+<!-- Version 2.4.4 -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# Version 2.4.4
+
+- Word-level `.active` class now updates on scrub-while-paused, so the default `.active > .active` CSS no longer goes blank during a paused scrub. Resolves #220.
+- `updateTranscriptVisualState` accepts an optional second argument (`forceActiveWord`) that lets callers opt into adding the word-level `.active` even when paused; `handleSeeked` passes `true`. Other call paths (playback loop, click handler) keep their existing behaviour, so this fixes the seek path without double-highlighting on click-while-paused.
+
 # Version 2.4.3
 
 - Transcript now follows media seeks, including scrub-while-paused — the read/unread visual state and scroll position re-align to the new playhead even when paused. Resolves #222.

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!-- Example index.html Copyright (C) BBC Research & Development - content used with kind permission of Ian Forrester https://twitter.com/cubicgarden/ -->
-<!-- Version 2.4.3 -->
+<!-- Version 2.4.4 -->
 
 <!DOCTYPE html>
 <html>

--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -1,5 +1,5 @@
 /*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
-/*! Version 2.4.3 */
+/*! Version 2.4.4 */
 
 'use strict';
 
@@ -582,12 +582,12 @@ class HyperaudioLite {
   }
 
   // Update transcript visual state + scroll position to match a seek (works while paused).
-  // Does not toggle the word-level `.active` class — `updateTranscriptVisualState`
-  // still defers that to the playing-state path.
+  // Forces the word-level `.active` class — without this, the default
+  // `.active > .active` CSS shows nothing on scrub-while-paused.
   handleSeeked() {
     (async () => {
       this.currentTime = await this.myPlayer.getTime();
-      const indices = this.updateTranscriptVisualState(this.currentTime);
+      const indices = this.updateTranscriptVisualState(this.currentTime, true);
       if (indices.currentWordIndex > 0 && this.autoscroll) {
         this.scrollToParagraph(indices.currentParentElementIndex, indices.currentWordIndex);
       }
@@ -751,7 +751,7 @@ class HyperaudioLite {
   }
 
   // Update the visual state of the transcript based on the current time
-  updateTranscriptVisualState(currentTime) {
+  updateTranscriptVisualState(currentTime, forceActiveWord = false) {
     let index = 0;
     let words = this.wordArr.length - 1;
 
@@ -787,7 +787,7 @@ class HyperaudioLite {
     Array.from(this.parentElements).forEach(el => el.classList.remove('active'));
 
     if (index > 0) {
-      if (!this.myPlayer.paused) {
+      if (!this.myPlayer.paused || forceActiveWord) {
         this.wordArr[index - 1].n.classList.add('active');
       }
       this.wordArr[index - 1].n.parentNode.classList.add('active');

--- a/multiplayer.html
+++ b/multiplayer.html
@@ -1,4 +1,4 @@
-<!-- Version 2.4.3 -->
+<!-- Version 2.4.4 -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Hyperaudio-Lite",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Hyperaudio-Lite",
-      "version": "2.4.3",
+      "version": "2.4.4",
       "license": "MIT",
       "devDependencies": {
         "jest": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Hyperaudio-Lite",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "license": "MIT",
   "devDependencies": {
     "jest": "^29.7.0",

--- a/soundcloud.html
+++ b/soundcloud.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.3 -->
+<!-- Last updated for Version 2.4.4 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/spotify.html
+++ b/spotify.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.3 -->
+<!-- Last updated for Version 2.4.4 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/videojs.html
+++ b/videojs.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.3 -->
+<!-- Last updated for Version 2.4.4 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/vidstack.html
+++ b/vidstack.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.3 -->
+<!-- Last updated for Version 2.4.4 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/vimeo.html
+++ b/vimeo.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.3 -->
+<!-- Last updated for Version 2.4.4 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/youtube-multiplayer.html
+++ b/youtube-multiplayer.html
@@ -1,4 +1,4 @@
-<!-- Version 2.4.3 -->
+<!-- Version 2.4.4 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/youtube.html
+++ b/youtube.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.3 -->
+<!-- Last updated for Version 2.4.4 -->
 
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
Fixes the bug reported in #220: anyone using HAL's default `.active > .active` styling sees nothing on scrub-while-paused, because the inner word's `.active` class was deliberately suppressed when `myPlayer.paused`. After v2.4.3 added seek-following, the paragraph's `.active` updates on scrub-while-paused but the word's doesn't — so descendant CSS still goes blank.

## Approach

We considered three options ([#220 comments](https://github.com/hyperaudio/hyperaudio-lite/issues/220)):

1. Drop the `!paused` conditional unconditionally — tried this first. **Broke the existing test for click-while-paused**: `setPlayHead` already adds `.active` to the clicked word manually, then calls `updateTranscriptVisualState` which (due to a binary-search off-by-one at exact word boundaries) adds `.active` to the *previous* word. Two consecutive words light up. Worse than the bug.
2. Add a constructor flag — same implementation problem, plus bloats the positional constructor (cf. #217).
3. **(Chosen)** Parameterize `updateTranscriptVisualState(currentTime, forceActiveWord = false)`. Only `handleSeeked` passes `true`. Playback loop, click handler, and initial-hash path keep their existing behaviour.

## Diff at the key site

```js
// in updateTranscriptVisualState
if (index > 0) {
  if (!this.myPlayer.paused || forceActiveWord) {   // <- was `!this.myPlayer.paused`
    this.wordArr[index - 1].n.classList.add('active');
  }
  this.wordArr[index - 1].n.parentNode.classList.add('active');
}

// in handleSeeked
const indices = this.updateTranscriptVisualState(this.currentTime, true);   // <- pass true
```

## Compat

- **Default behaviour unchanged** for the playback loop, click handler, and initial hash path.
- **Scrub-while-paused** now also lights up the active word, so `.active > .active` default CSS works. This is a deliberate behavioural change — the previous behaviour was the bug.
- New `forceActiveWord` parameter has a `false` default so existing external callers (if any) keep their current behaviour.

## Test plan

- [x] `npm test` — all 25 Jest tests pass (including the click-while-paused test that option 1 broke)
- [ ] Manual: `index.html` — play for ~10s, pause, scrub via the seek bar, confirm both the paragraph AND the word light up at the new playhead
- [ ] Manual: confirm clicking a word while paused still only highlights the clicked word (no double-highlight regression)