### PR TITLE
Fix multi-instance YouTube wiring (resolves #226)

### DIFF
--- a/active.html
+++ b/active.html
@@ -1,5 +1,5 @@
 <!-- Example index.html Copyright (C) BBC Research & Development - content used with kind permission of Ian Forrester https://twitter.com/cubicgarden/ -->
-<!-- Version 2.4.6 -->
+<!-- Version 2.4.7 -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# Version 2.4.7
+
+- Fixed multi-instance YouTube wiring: when more than one HAL instance backed by a YouTube iframe was created on the same page, `window.onYouTubeIframeAPIReady` was overwritten by each new instance, so only the last instance's `YT.Player` actually got set up — leaving earlier instances unable to seek, play, pause, or follow playback. Each instance now chains onto any existing callback (and wires up immediately if the API is already loaded). Resolves #226.
+
 # Version 2.4.6
 
 - `multiplayer.html` demo now coordinates its two players so only one plays at a time — pressing play on either pauses the other. The library itself is unchanged; consumers running multiple instances on a page can apply the same pattern. (See `youtube-multiplayer.html` for a known remaining case of the same UX issue.)

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!-- Example index.html Copyright (C) BBC Research & Development - content used with kind permission of Ian Forrester https://twitter.com/cubicgarden/ -->
-<!-- Version 2.4.6 -->
+<!-- Version 2.4.7 -->
 
 <!DOCTYPE html>
 <html>

--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -1,5 +1,5 @@
 /*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
-/*! Version 2.4.6 */
+/*! Version 2.4.7 */
 
 'use strict';
 
@@ -142,8 +142,19 @@ class YouTubePlayer extends BasePlayer {
       firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
     }
 
-    // Set the global callback for the YouTube IFrame API
-    window.onYouTubeIframeAPIReady = this.onYouTubeIframeAPIReady.bind(this, instance);
+    // If the API has already loaded (e.g. another instance was created first
+    // and the script has finished loading), wire up immediately. Otherwise
+    // chain onto any existing onYouTubeIframeAPIReady so multiple instances on
+    // the same page don't clobber each other's setup.
+    if (window.YT && window.YT.Player) {
+      this.onYouTubeIframeAPIReady(instance);
+    } else {
+      const prev = window.onYouTubeIframeAPIReady;
+      window.onYouTubeIframeAPIReady = () => {
+        if (typeof prev === 'function') prev();
+        this.onYouTubeIframeAPIReady(instance);
+      };
+    }
   }
 
   // Callback when YouTube IFrame API is ready

--- a/multiplayer.html
+++ b/multiplayer.html
@@ -1,4 +1,4 @@
-<!-- Version 2.4.6 -->
+<!-- Version 2.4.7 -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Hyperaudio-Lite",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Hyperaudio-Lite",
-      "version": "2.4.6",
+      "version": "2.4.7",
       "license": "MIT",
       "devDependencies": {
         "jest": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Hyperaudio-Lite",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "license": "MIT",
   "devDependencies": {
     "jest": "^29.7.0",

--- a/soundcloud.html
+++ b/soundcloud.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.6 -->
+<!-- Last updated for Version 2.4.7 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/spotify.html
+++ b/spotify.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.6 -->
+<!-- Last updated for Version 2.4.7 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/videojs.html
+++ b/videojs.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.6 -->
+<!-- Last updated for Version 2.4.7 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/vidstack.html
+++ b/vidstack.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.6 -->
+<!-- Last updated for Version 2.4.7 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/vimeo.html
+++ b/vimeo.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.6 -->
+<!-- Last updated for Version 2.4.7 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/youtube-multiplayer.html
+++ b/youtube-multiplayer.html
@@ -1,4 +1,4 @@
-<!-- Version 2.4.6 -->
+<!-- Version 2.4.7 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/youtube.html
+++ b/youtube.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.6 -->
+<!-- Last updated for Version 2.4.7 -->
 
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
Each `YouTubePlayer.initPlayer` previously did:

```js
window.onYouTubeIframeAPIReady = this.onYouTubeIframeAPIReady.bind(this, instance);
```

— overwriting whatever the previous instance had set there. The YouTube IFrame API calls that global slot **once** when its script finishes loading, so on a page with multiple HAL instances backed by YouTube iframes, only the **last** instance's `YT.Player` actually got created. Earlier instances were left with `isReady = false`, which short-circuits `setTime`, `getTime`, `play`, and `pause` — the transcript ↔ video link is silently broken for every instance except the last (the iframe still plays via YouTube's own native controls, which is why the bug is easy to miss).

## Fix

```js
if (window.YT && window.YT.Player) {
  this.onYouTubeIframeAPIReady(instance);
} else {
  const prev = window.onYouTubeIframeAPIReady;
  window.onYouTubeIframeAPIReady = () => {
    if (typeof prev === 'function') prev();
    this.onYouTubeIframeAPIReady(instance);
  };
}
```

Each instance now chains onto whatever was there before instead of clobbering it, so all instances' setup runs when the API fires the callback. If the API has already loaded (e.g. a third instance is added after the others have bootstrapped), wire up immediately.

## Compat

- **No public API change.** Single-YouTube-instance pages behave identically.
- **Multi-instance pages start working** for the first time. If anyone was working around the bug downstream (e.g. by recreating `YT.Player` themselves like `youtube-multiplayer.html` does in its coordination code), their workaround keeps working — multiple `YT.Player` wrappers per iframe coexist fine.

## Test plan

- [x] `npm test` — all 25 Jest tests pass
- [ ] Manual: open `youtube-multiplayer.html`, click a word in transcript 1 — video 1 should now seek (previously did nothing)
- [ ] Manual: click a word in transcript 2 — video 2 should still seek correctly
- [ ] Manual: play either video — the transcript should follow playback (previously only worked for the last-instantiated player)