### PR TITLE
Clear stale .active on rewind (resolves #231)

### DIFF
--- a/__TEST__/hyperaudio-lite.test.js
+++ b/__TEST__/hyperaudio-lite.test.js
@@ -257,6 +257,22 @@ test("updateTranscriptVisualState marks words as read", () => {
   expect(spans[5].classList.contains('unread')).toBe(true);
 });
 
+test("updateTranscriptVisualState clears stale .active on rewind", () => {
+  // Play forward past the 5th word — that word ends up active.
+  ht.myPlayer = { paused: false };
+  ht.updateTranscriptVisualState(5);
+  // Then rewind to time 0. Words that were ahead of the playhead used to keep
+  // their .active class because the else-branch only removed 'read', not
+  // 'active' — leaving contradictory `active unread` words behind the new
+  // playhead. (regression for #231)
+  ht.updateTranscriptVisualState(0, true);
+  const spans = document.querySelectorAll('span');
+  const staleActives = Array.from(spans).filter(
+    s => s.classList.contains('active') && s.classList.contains('unread')
+  );
+  expect(staleActives).toHaveLength(0);
+});
+
 test("setPlayHead updates currentTime and plays if playOnClick is true", () => {
   ht.playOnClick = true;
   ht.myPlayer = { setTime: jest.fn(), play: jest.fn(), paused: true };

--- a/active.html
+++ b/active.html
@@ -1,5 +1,5 @@
 <!-- Example index.html Copyright (C) BBC Research & Development - content used with kind permission of Ian Forrester https://twitter.com/cubicgarden/ -->
-<!-- Version 2.4.7 -->
+<!-- Version 2.4.8 -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# Version 2.4.8
+
+- Fixed a stale `.active` class on rewind/scrub-backward: `updateTranscriptVisualState` only removed `active` from words *before* the playhead, so seeking backward left a trail of contradictory `active unread` words ahead of the new position. The else-branch now clears `active` too, and `setPlayHead` was reordered to mark its clicked word after the visual-state update (so the click-while-paused active-mark survives the new sweep). Resolves #231. Bug introduced in v2.4.3 (seek-follow work).
+
 # Version 2.4.7
 
 - Fixed multi-instance YouTube wiring: when more than one HAL instance backed by a YouTube iframe was created on the same page, `window.onYouTubeIframeAPIReady` was overwritten by each new instance, so only the last instance's `YT.Player` actually got set up — leaving earlier instances unable to seek, play, pause, or follow playback. Each instance now chains onto any existing callback (and wires up immediately if the API is already loaded). Resolves #226.

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!-- Example index.html Copyright (C) BBC Research & Development - content used with kind permission of Ian Forrester https://twitter.com/cubicgarden/ -->
-<!-- Version 2.4.7 -->
+<!-- Version 2.4.8 -->
 
 <!DOCTYPE html>
 <html>

--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -1,5 +1,5 @@
 /*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
-/*! Version 2.4.7 */
+/*! Version 2.4.8 */
 
 'use strict';
 
@@ -557,13 +557,17 @@ class HyperaudioLite {
     this.highlightedText = false;
     this.clearActiveClasses();
 
+    const timeSecs = parseInt(target.dataset.m) / 1000;
+    this.updateTranscriptVisualState(timeSecs);
+
+    // Mark the clicked word as active AFTER updateTranscriptVisualState (which
+    // now wipes stale .active in its else-branch to fix #231). When playing,
+    // the playback loop owns the active word; when paused, we explicitly mark
+    // the clicked word so the user sees what they clicked.
     if (this.myPlayer.paused && target.dataset.m) {
       target.classList.add('active');
       target.parentNode.classList.add('active');
     }
-
-    const timeSecs = parseInt(target.dataset.m) / 1000;
-    this.updateTranscriptVisualState(timeSecs);
 
     if (!isNaN(timeSecs)) {
       this.end = null;
@@ -790,7 +794,7 @@ class HyperaudioLite {
         parentClassList.remove('active');
       } else {
         classList.add('unread');
-        classList.remove('read');
+        classList.remove('read', 'active');
       }
     });
 

--- a/multiplayer.html
+++ b/multiplayer.html
@@ -1,4 +1,4 @@
-<!-- Version 2.4.7 -->
+<!-- Version 2.4.8 -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Hyperaudio-Lite",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Hyperaudio-Lite",
-      "version": "2.4.7",
+      "version": "2.4.8",
       "license": "MIT",
       "devDependencies": {
         "jest": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Hyperaudio-Lite",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "license": "MIT",
   "devDependencies": {
     "jest": "^29.7.0",

--- a/soundcloud.html
+++ b/soundcloud.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.7 -->
+<!-- Last updated for Version 2.4.8 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/spotify.html
+++ b/spotify.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.7 -->
+<!-- Last updated for Version 2.4.8 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/videojs.html
+++ b/videojs.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.7 -->
+<!-- Last updated for Version 2.4.8 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/vidstack.html
+++ b/vidstack.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.7 -->
+<!-- Last updated for Version 2.4.8 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/vimeo.html
+++ b/vimeo.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.7 -->
+<!-- Last updated for Version 2.4.8 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/youtube-multiplayer.html
+++ b/youtube-multiplayer.html
@@ -1,4 +1,4 @@
-<!-- Version 2.4.7 -->
+<!-- Version 2.4.8 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/youtube.html
+++ b/youtube.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.7 -->
+<!-- Last updated for Version 2.4.8 -->
 
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
Bug introduced by v2.4.3's seek-follow work: `updateTranscriptVisualState` only removed `.active` from words *before* the playhead, leaving every previously-active word in a contradictory `active unread` state when seeking/scrubbing backward.

## Fix

Two coordinated changes:

1. **\`updateTranscriptVisualState\` else-branch wipes \`.active\`** — words at/after the playhead now lose `.active` too, not just words before it:
   ```js
   } else {
     classList.add('unread');
     classList.remove('read', 'active');   // was: classList.remove('read')
   }
   ```

2. **\`setPlayHead\` reordered** — the click-while-paused manual `.active` mark now happens AFTER `updateTranscriptVisualState`, otherwise the new sweep would wipe it on the same call.

## Regression test

Added: `updateTranscriptVisualState clears stale .active on rewind`. Plays forward (so words gain `.active`), then rewinds to time 0, then asserts no spans have both `.active` and `.unread` simultaneously. Without the fix, the test fails.

## Compat

- No public API change.
- Behaviour change is the bug fix itself: scrub-backward no longer leaves a trail of falsely-highlighted words.
- All other paths (forward playback, click-while-paused, click-while-playing, scrub-while-paused for the active-word case from #220) keep their existing behaviour. 26/26 tests pass.

## Test plan

- [x] `npm test` — 26/26 pass (25 existing + 1 new regression test)
- [ ] Manual: play `index.html`, scrub backward, confirm no stale highlighted words behind the playhead
- [ ] Manual: pause, click a word — only that word lights up (no double-highlight regression)