### PR TITLE
Make BasePlayer abstract; move HTML5 defaults to NativePlayer (refs #214)

### DIFF
--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -25,26 +25,23 @@ class BasePlayer {
     this.player.addEventListener('seeked', instance.handleSeeked.bind(instance), false);
   }
 
-  // Method to get the current time of the player
+  // Contract methods — subclasses must implement these for their player's API.
+  // BasePlayer is intentionally abstract; previous HTML5 defaults now live in
+  // NativePlayer so non-native subclasses can't silently inherit wrong behaviour.
   getTime() {
-    return Promise.resolve(this.player.currentTime);
+    throw new Error('getTime must be implemented by subclasses');
   }
 
-  // Method to set the current time of the player
   setTime(seconds) {
-    this.player.currentTime = seconds;
+    throw new Error('setTime must be implemented by subclasses');
   }
 
-  // Method to play the media
   play() {
-    this.player.play();
-    this.paused = false;
+    throw new Error('play must be implemented by subclasses');
   }
 
-  // Method to pause the media
   pause() {
-    this.player.pause();
-    this.paused = true;
+    throw new Error('pause must be implemented by subclasses');
   }
 }
 
@@ -53,6 +50,24 @@ class NativePlayer extends BasePlayer {
   // Initialize the native HTML5 player
   initPlayer(instance) {
     return instance.player;
+  }
+
+  getTime() {
+    return Promise.resolve(this.player.currentTime);
+  }
+
+  setTime(seconds) {
+    this.player.currentTime = seconds;
+  }
+
+  play() {
+    this.player.play();
+    this.paused = false;
+  }
+
+  pause() {
+    this.player.pause();
+    this.paused = true;
   }
 }
 

--- a/js/hyperaudio-lite.mjs
+++ b/js/hyperaudio-lite.mjs
@@ -25,26 +25,23 @@ class BasePlayer {
     this.player.addEventListener('seeked', instance.handleSeeked.bind(instance), false);
   }
 
-  // Method to get the current time of the player
+  // Contract methods — subclasses must implement these for their player's API.
+  // BasePlayer is intentionally abstract; previous HTML5 defaults now live in
+  // NativePlayer so non-native subclasses can't silently inherit wrong behaviour.
   getTime() {
-    return Promise.resolve(this.player.currentTime);
+    throw new Error('getTime must be implemented by subclasses');
   }
 
-  // Method to set the current time of the player
   setTime(seconds) {
-    this.player.currentTime = seconds;
+    throw new Error('setTime must be implemented by subclasses');
   }
 
-  // Method to play the media
   play() {
-    this.player.play();
-    this.paused = false;
+    throw new Error('play must be implemented by subclasses');
   }
 
-  // Method to pause the media
   pause() {
-    this.player.pause();
-    this.paused = true;
+    throw new Error('pause must be implemented by subclasses');
   }
 }
 
@@ -53,6 +50,24 @@ class NativePlayer extends BasePlayer {
   // Initialize the native HTML5 player
   initPlayer(instance) {
     return instance.player;
+  }
+
+  getTime() {
+    return Promise.resolve(this.player.currentTime);
+  }
+
+  setTime(seconds) {
+    this.player.currentTime = seconds;
+  }
+
+  play() {
+    this.player.play();
+    this.paused = false;
+  }
+
+  pause() {
+    this.player.pause();
+    this.paused = true;
   }
 }
 


### PR DESCRIPTION
Part of the 2.5 release scope. Pure design-hygiene refactor — no behavioural change at runtime.

## Before

\`BasePlayer.getTime/setTime/play/pause\` provided HTML5-flavoured working defaults that only made sense for the native \`<audio>\`/\`<video>\` case. Every non-native subclass (SoundCloud, VideoJS, Vimeo, YouTube, Spotify) had to override all four; \`NativePlayer\` was the only one that benefited from the inheritance.

## After

\`BasePlayer\` becomes a proper abstract contract: its four methods throw \`"<name> must be implemented by subclasses"\`. The HTML5 implementations move down into \`NativePlayer\`, which now explicitly defines them.

```js
class BasePlayer {
  // ...
  getTime() { throw new Error('getTime must be implemented by subclasses'); }
  setTime(seconds) { throw new Error('setTime must be implemented by subclasses'); }
  play()    { throw new Error('play must be implemented by subclasses'); }
  pause()   { throw new Error('pause must be implemented by subclasses'); }
}

class NativePlayer extends BasePlayer {
  initPlayer(instance) { return instance.player; }
  getTime() { return Promise.resolve(this.player.currentTime); }
  setTime(seconds) { this.player.currentTime = seconds; }
  play()    { this.player.play(); this.paused = false; }
  pause()   { this.player.pause(); this.paused = true; }
}
```

Other player subclasses are unchanged — they were already overriding all four methods.

## Why

- The class signals the **contract** ("every player implements these four"), not a particular implementation that happens to work for one case.
- Future contributors adding a new player type (HLS, Wistia, etc.) can't accidentally inherit silently-wrong HTML5 behaviour by forgetting to override one method — they'd get a clear error at instantiation time.
- `NativePlayer` stops being "the special one that doesn't have to do anything." Its HTML5-ness is explicit at the call site rather than implicit through inheritance.

## Compat

- **No public API change.** \`HyperaudioLite\` constructor signature, behaviour, and properties all unchanged.
- **No behavioural change at runtime.** Every concrete player subclass implements all four methods, so the contract throws are never reached in normal use.
- All 26 Jest tests pass.

## Files touched

- \`js/hyperaudio-lite.js\` — abstract BasePlayer + explicit NativePlayer
- \`js/hyperaudio-lite.mjs\` — regenerated from .js (drift kept in sync per the manual-maintenance approach agreed for the 2.5 cycle)

No version bump — final 2.5.0 release commit bumps everything together.

## Test plan

- [x] \`npm test\` — 26/26 pass
- [ ] Manual smoke check: confirm native, YouTube, SoundCloud, Vimeo demos load and play normally