### PR TITLE
Fix clicked-word off-by-one in binary search (resolves #235)

### DIFF
--- a/__TEST__/hyperaudio-lite.test.js
+++ b/__TEST__/hyperaudio-lite.test.js
@@ -257,6 +257,19 @@ test("updateTranscriptVisualState marks words as read", () => {
   expect(spans[5].classList.contains('unread')).toBe(true);
 });
 
+test("updateTranscriptVisualState marks the matched word as active at exact word boundaries", () => {
+  // Regression for #235: clicking a word sets currentTime to the word's exact
+  // start time. The binary search used to return index = matchedIndex (treating
+  // the matched word as "not yet started") so wordArr[index - 1] — the previous
+  // word — was marked active. Visible as the wrong word lighting up on every click.
+  ht.myPlayer = { paused: false };
+  const word = document.getElementsByTagName('span')[4];
+  const exactStart = parseInt(word.dataset.m) / 1000;
+  ht.updateTranscriptVisualState(exactStart);
+  expect(word.classList.contains('active')).toBe(true);
+  expect(document.getElementsByTagName('span')[3].classList.contains('active')).toBe(false);
+});
+
 test("updateTranscriptVisualState clears stale .active on rewind", () => {
   // Play forward past the 5th word — that word ends up active.
   ht.myPlayer = { paused: false };

--- a/active.html
+++ b/active.html
@@ -1,5 +1,5 @@
 <!-- Example index.html Copyright (C) BBC Research & Development - content used with kind permission of Ian Forrester https://twitter.com/cubicgarden/ -->
-<!-- Version 2.4.8 -->
+<!-- Version 2.4.9 -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# Version 2.4.9
+
+- Fixed a long-standing off-by-one in the transcript visual-state binary search: at exact word boundaries (which is what every word-click produces, since the click sets `currentTime` to the word's exact start), the search returned the matched index and downstream code marked `wordArr[index - 1]` (the **previous** word) as active. Visible as the wrong word lighting up on every word-click with the default `playOnClick: true` setting. Resolves #235.
+
 # Version 2.4.8
 
 - Fixed a stale `.active` class on rewind/scrub-backward: `updateTranscriptVisualState` only removed `active` from words *before* the playhead, so seeking backward left a trail of contradictory `active unread` words ahead of the new position. The else-branch now clears `active` too, and `setPlayHead` was reordered to mark its clicked word after the visual-state update (so the click-while-paused active-mark survives the new sweep). Resolves #231. Bug introduced in v2.4.3 (seek-follow work).

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!-- Example index.html Copyright (C) BBC Research & Development - content used with kind permission of Ian Forrester https://twitter.com/cubicgarden/ -->
-<!-- Version 2.4.8 -->
+<!-- Version 2.4.9 -->
 
 <!DOCTYPE html>
 <html>

--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -1,5 +1,5 @@
 /*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
-/*! Version 2.4.8 */
+/*! Version 2.4.9 */
 
 'use strict';
 
@@ -779,7 +779,12 @@ class HyperaudioLite {
       } else if (difference > 0) {
         words = guessIndex - 1;
       } else {
-        index = guessIndex;
+        // Exact match: treat the matched word as having just started, so
+        // wordArr[index - 1] (used downstream as the active word) points to
+        // this word, not the previous one. Without the +1 we'd land an
+        // off-by-one at every word boundary — visible on every click,
+        // since clicks set currentTime to a word's exact start time.
+        index = guessIndex + 1;
         break;
       }
     }

--- a/js/hyperaudio-lite.mjs
+++ b/js/hyperaudio-lite.mjs
@@ -1,5 +1,5 @@
 /*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
-/*! Version 2.4.8 */
+/*! Version 2.4.9 */
 
 'use strict';
 
@@ -779,7 +779,12 @@ class HyperaudioLite {
       } else if (difference > 0) {
         words = guessIndex - 1;
       } else {
-        index = guessIndex;
+        // Exact match: treat the matched word as having just started, so
+        // wordArr[index - 1] (used downstream as the active word) points to
+        // this word, not the previous one. Without the +1 we'd land an
+        // off-by-one at every word boundary — visible on every click,
+        // since clicks set currentTime to a word's exact start time.
+        index = guessIndex + 1;
         break;
       }
     }

--- a/multiplayer.html
+++ b/multiplayer.html
@@ -1,4 +1,4 @@
-<!-- Version 2.4.8 -->
+<!-- Version 2.4.9 -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Hyperaudio-Lite",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Hyperaudio-Lite",
-      "version": "2.4.8",
+      "version": "2.4.9",
       "license": "MIT",
       "devDependencies": {
         "jest": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Hyperaudio-Lite",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "license": "MIT",
   "main": "./js/hyperaudio-lite.js",
   "module": "./js/hyperaudio-lite.mjs",

--- a/soundcloud.html
+++ b/soundcloud.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.8 -->
+<!-- Last updated for Version 2.4.9 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/spotify.html
+++ b/spotify.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.8 -->
+<!-- Last updated for Version 2.4.9 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/videojs.html
+++ b/videojs.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.8 -->
+<!-- Last updated for Version 2.4.9 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/vidstack.html
+++ b/vidstack.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.8 -->
+<!-- Last updated for Version 2.4.9 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/vimeo.html
+++ b/vimeo.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.8 -->
+<!-- Last updated for Version 2.4.9 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/youtube-multiplayer.html
+++ b/youtube-multiplayer.html
@@ -1,4 +1,4 @@
-<!-- Version 2.4.8 -->
+<!-- Version 2.4.9 -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/youtube.html
+++ b/youtube.html
@@ -1,4 +1,4 @@
-<!-- Last updated for Version 2.4.8 -->
+<!-- Last updated for Version 2.4.9 -->
 
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
Bug surfaced by user testing: clicking a word with the default \`playOnClick: true\` highlights the **previous** word instead of the one clicked.

## Root cause

\`updateTranscriptVisualState\`'s binary search treated exact matches as "matched word not yet started":

```js
} else {                  // difference === 0 (exact match)
  index = guessIndex;
  break;
}
```

Downstream code marks \`wordArr[index - 1]\` as \`.active\` — at a click (which sets \`currentTime\` to the word's exact start), that's the *previous* word. Mid-word \`currentTime\` values landed at \`index = matched + 1\` via the \`difference < 0\` branch, so they were always correct; only exact boundaries hit the bug.

## Fix

```js
} else {
  index = guessIndex + 1;   // was: index = guessIndex
  break;
}
```

Now \`wordArr[index - 1]\` is the matched word itself — exact-boundary semantics match the mid-word semantics. No \`setPlayHead\` special-casing needed; the manual paused-mark and the playback loop agree on which word is active.

## Regression test

```js
test("updateTranscriptVisualState marks the matched word as active at exact word boundaries", () => {
  ht.myPlayer = { paused: false };
  const word = document.getElementsByTagName('span')[4];
  const exactStart = parseInt(word.dataset.m) / 1000;
  ht.updateTranscriptVisualState(exactStart);
  expect(word.classList.contains('active')).toBe(true);
  expect(document.getElementsByTagName('span')[3].classList.contains('active')).toBe(false);
});
```

Fails without the fix; passes with it.

## Why now

The bug has been latent in the binary-search logic for a long time. It surfaced more visibly after v2.4.3's seek-follow work + v2.4.8's stale-\`.active\`-clear made the playback loop more thorough at clearing the manual mark \`setPlayHead\` adds when paused. Before those changes, \`setPlayHead\`'s manual mark survived longer and partially masked the off-by-one.

## Compat

- No public API change.
- Behavioural change is the bug fix itself: clicked words now light up correctly.
- \`forceActiveWord\` (added in v2.4.4 for #220 scrub-while-paused) and the \`setPlayHead\` reorder (v2.4.8 for #231) both remain — they handle different cases (mid-word seek; click-while-paused interaction) and still apply.
- 27/27 tests pass.

## Test plan

- [x] \`npm test\` — 26 existing + 1 new = 27/27 pass
- [ ] Manual: \`index.html\`, pause, click various words, confirm the **clicked** word lights up (not the previous one)
- [ ] Manual: \`index.html\`, normal playback regression check — active word follows playhead correctly mid-word
- [ ] Manual: scrub while paused — active word still highlights at the new playhead (regression check for #220)
- [ ] Manual: rewind during playback — no stale \`.active\` words behind playhead (regression check for #231)