### PR TITLE
Options-object constructor with positional backward compatibility (refs #217)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,16 +161,36 @@ const { HyperaudioLite } = require('hyperaudio-lite');
 
 The classic `<script>` form still works exactly as before. Bundlers and Node resolve to `js/hyperaudio-lite.mjs` (ESM) or `js/hyperaudio-lite.js` (CJS) automatically via the package's `exports` map.
 
-Finally instantiate the Transcript Player:
+Finally instantiate the Transcript Player. Pass an options object identifying the transcript and player elements (by `id`), plus any optional behaviour flags:
 
 ```javascript
-let minimizedMode = false;
-let autoScroll = true;
-let doubleClick = false;
-let webMonetization = false;
-let playOnClick = true;
+new HyperaudioLite({
+  transcript: "hypertranscript",
+  player: "hyperplayer",
+  autoScroll: true,
+  playOnClick: true,
+});
+```
 
-new HyperaudioLite("hypertranscript", "hyperplayer", minimizedMode, autoScroll, doubleClick, webMonetization, playOnClick);
+All options:
+
+| Option | Default | Description |
+|---|---|---|
+| `transcript` | _(required)_ | Element id of the transcript container |
+| `player` | _(required)_ | Element id of the audio/video element (or third-party player iframe) |
+| `autoScroll` | `true` | Scroll the transcript to follow playback and seeks |
+| `playOnClick` | `true` | Start playback when the user clicks a word |
+| `doubleClick` | `false` | Require a double-click instead of a single click for word interaction |
+| `minimizedMode` | `false` | Show the current word in the browser tab title (experimental) |
+| `webMonetization` | `false` | Inject `<link rel="monetization">` from `data-wm` payment pointers in the transcript |
+
+#### Deprecated positional form
+
+The original positional-argument form still works for backward compatibility across the 2.x line, but is no longer recommended:
+
+```javascript
+// Deprecated — emits a console warning
+new HyperaudioLite("hypertranscript", "hyperplayer", false, true, false, false, true);
 ```
 
 ### Autoscroll behaviour
@@ -180,7 +200,7 @@ When `autoScroll` is enabled, the transcript follows playback and also follows s
 To temporarily disable autoscroll (e.g. while a user is editing the transcript), call `pauseAutoscroll()` and re-enable it with `resumeAutoscroll()`:
 
 ```javascript
-const player = new HyperaudioLite("hypertranscript", "hyperplayer", false, true, false, false, true);
+const player = new HyperaudioLite({ transcript: "hypertranscript", player: "hyperplayer" });
 player.pauseAutoscroll();
 // ...later
 player.resumeAutoscroll();

--- a/__TEST__/hyperaudio-lite.test.js
+++ b/__TEST__/hyperaudio-lite.test.js
@@ -23,6 +23,65 @@ test("initialization with parameters", () => {
   expect(customHt.playOnClick).toBe(true);
 });
 
+test("initialization with options object — all flags explicit", () => {
+  const customHt = new HyperaudioLite({
+    transcript: "hypertranscript",
+    player: "hyperplayer",
+    minimizedMode: true,
+    autoScroll: true,
+    doubleClick: true,
+    webMonetization: true,
+    playOnClick: true,
+  });
+
+  expect(customHt.minimizedMode).toBe(true);
+  expect(customHt.autoscroll).toBe(true);
+  expect(customHt.doubleClick).toBe(true);
+  expect(customHt.webMonetization).toBe(true);
+  expect(customHt.playOnClick).toBe(true);
+});
+
+test("initialization with options object — defaults applied for omitted flags", () => {
+  const customHt = new HyperaudioLite({
+    transcript: "hypertranscript",
+    player: "hyperplayer",
+  });
+
+  // Defaults from the constructor: minimizedMode=false, autoScroll=true,
+  // doubleClick=false, webMonetization=false, playOnClick=true.
+  expect(customHt.minimizedMode).toBe(false);
+  expect(customHt.autoscroll).toBe(true);
+  expect(customHt.doubleClick).toBe(false);
+  expect(customHt.webMonetization).toBe(false);
+  expect(customHt.playOnClick).toBe(true);
+});
+
+test("positional constructor emits a deprecation warning (once)", () => {
+  // Reset the throttle flag so the warning will fire for this test, regardless
+  // of test order.
+  HyperaudioLite._positionalWarned = false;
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+  new HyperaudioLite("hypertranscript", "hyperplayer", false, true, false, false, true);
+  new HyperaudioLite("hypertranscript", "hyperplayer", false, true, false, false, true);
+
+  // Throttled to once per page load, regardless of how many positional calls happen.
+  expect(warnSpy).toHaveBeenCalledTimes(1);
+  expect(warnSpy.mock.calls[0][0]).toMatch(/positional-argument constructor is deprecated/);
+
+  warnSpy.mockRestore();
+});
+
+test("options-object constructor does NOT emit a deprecation warning", () => {
+  HyperaudioLite._positionalWarned = false;
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+  new HyperaudioLite({ transcript: "hypertranscript", player: "hyperplayer" });
+
+  expect(warnSpy).not.toHaveBeenCalled();
+  warnSpy.mockRestore();
+});
+
 function createWordArrayResult(words) {
   for (let i = 0; i < words.length; ++i) {
     const m = parseInt(words[i].getAttribute("data-m"));

--- a/active.html
+++ b/active.html
@@ -1036,14 +1036,13 @@
   <script src="js/caption.js"></script>
   <script>
 
-  // minimizedMode is still experimental - it aims to show the current words in the title, which can be seen on the browser tab.
-  let minimizedMode = false;
-  let autoScroll = true;
-  let doubleClick = false;
-  let webMonetization = true;
-  let playOnClick = false;
-
-  new HyperaudioLite("hypertranscript", "hyperplayer", minimizedMode, autoScroll, doubleClick, webMonetization, playOnClick);
+  new HyperaudioLite({
+    transcript: "hypertranscript",
+    player: "hyperplayer",
+    autoScroll: true,
+    webMonetization: true,
+    playOnClick: false,
+  });
 
   // Override scroll parameters
   //ht1.setScrollParameters(<duration>, <delay>, <offset>, <container>);

--- a/index.html
+++ b/index.html
@@ -1039,14 +1039,12 @@
   <script src="js/caption.js"></script>
   <script>
 
-  // minimizedMode is still experimental - it aims to show the current words in the title, which can be seen on the browser tab.
-  let minimizedMode = false;
-  let autoScroll = true;
-  let doubleClick = false;
-  let webMonetization = false;
-  let playOnClick = false;
-
-  new HyperaudioLite("hypertranscript", "hyperplayer", minimizedMode, autoScroll, doubleClick, webMonetization, playOnClick);
+  new HyperaudioLite({
+    transcript: "hypertranscript",
+    player: "hyperplayer",
+    autoScroll: true,
+    playOnClick: false,
+  });
 
   // Override scroll parameters
   //ht1.setScrollParameters(<duration>, <delay>, <offset>, <container>);

--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -312,9 +312,32 @@ function hyperaudioPlayer(playerType, instance) {
 
 // Main class for HyperaudioLite functionality
 class HyperaudioLite {
-  constructor(transcriptId, mediaElementId, minimizedMode, autoscroll, doubleClick, webMonetization, playOnClick) {
-    this.transcript = document.getElementById(transcriptId);
-    this.init(mediaElementId, minimizedMode, autoscroll, doubleClick, webMonetization, playOnClick);
+  // Constructor accepts EITHER form:
+  //   new HyperaudioLite({ transcript, player, autoScroll, ... })   -- recommended
+  //   new HyperaudioLite(transcriptId, mediaElementId, ...flags)    -- deprecated, kept for BC
+  // The positional form continues to work indefinitely across the 2.x line.
+  constructor(...args) {
+    let opts;
+    if (typeof args[0] === 'object' && args[0] !== null) {
+      // Options-object form. Apply sensible defaults so common cases stay short.
+      opts = {
+        minimizedMode: false,
+        autoScroll: true,
+        doubleClick: false,
+        webMonetization: false,
+        playOnClick: true,
+        ...args[0],
+      };
+    } else {
+      // Legacy positional form. Pass values through without applying defaults
+      // so existing callers get identical behaviour (undefined stays undefined).
+      HyperaudioLite._warnPositionalOnce();
+      const [transcript, player, minimizedMode, autoScroll, doubleClick, webMonetization, playOnClick] = args;
+      opts = { transcript, player, minimizedMode, autoScroll, doubleClick, webMonetization, playOnClick };
+    }
+
+    this.transcript = document.getElementById(opts.transcript);
+    this.init(opts.player, opts.minimizedMode, opts.autoScroll, opts.doubleClick, opts.webMonetization, opts.playOnClick);
 
     // Ensure correct binding for class methods
     this.preparePlayHead = this.preparePlayHead.bind(this);
@@ -323,6 +346,20 @@ class HyperaudioLite {
     this.checkPlayHead = this.checkPlayHead.bind(this);
     this.clearTimer = this.clearTimer.bind(this);
     this.handleSeeked = this.handleSeeked.bind(this);
+  }
+
+  // Throttled deprecation warning — fires at most once per page load
+  // regardless of how many positional-form constructions happen.
+  static _warnPositionalOnce() {
+    if (HyperaudioLite._positionalWarned) return;
+    HyperaudioLite._positionalWarned = true;
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn(
+        'HyperaudioLite: the positional-argument constructor is deprecated. ' +
+        'Pass an options object instead — see the README. The positional form ' +
+        'continues to work across the 2.x line.'
+      );
+    }
   }
 
   // Initialize the HyperaudioLite instance

--- a/js/hyperaudio-lite.mjs
+++ b/js/hyperaudio-lite.mjs
@@ -312,9 +312,32 @@ function hyperaudioPlayer(playerType, instance) {
 
 // Main class for HyperaudioLite functionality
 class HyperaudioLite {
-  constructor(transcriptId, mediaElementId, minimizedMode, autoscroll, doubleClick, webMonetization, playOnClick) {
-    this.transcript = document.getElementById(transcriptId);
-    this.init(mediaElementId, minimizedMode, autoscroll, doubleClick, webMonetization, playOnClick);
+  // Constructor accepts EITHER form:
+  //   new HyperaudioLite({ transcript, player, autoScroll, ... })   -- recommended
+  //   new HyperaudioLite(transcriptId, mediaElementId, ...flags)    -- deprecated, kept for BC
+  // The positional form continues to work indefinitely across the 2.x line.
+  constructor(...args) {
+    let opts;
+    if (typeof args[0] === 'object' && args[0] !== null) {
+      // Options-object form. Apply sensible defaults so common cases stay short.
+      opts = {
+        minimizedMode: false,
+        autoScroll: true,
+        doubleClick: false,
+        webMonetization: false,
+        playOnClick: true,
+        ...args[0],
+      };
+    } else {
+      // Legacy positional form. Pass values through without applying defaults
+      // so existing callers get identical behaviour (undefined stays undefined).
+      HyperaudioLite._warnPositionalOnce();
+      const [transcript, player, minimizedMode, autoScroll, doubleClick, webMonetization, playOnClick] = args;
+      opts = { transcript, player, minimizedMode, autoScroll, doubleClick, webMonetization, playOnClick };
+    }
+
+    this.transcript = document.getElementById(opts.transcript);
+    this.init(opts.player, opts.minimizedMode, opts.autoScroll, opts.doubleClick, opts.webMonetization, opts.playOnClick);
 
     // Ensure correct binding for class methods
     this.preparePlayHead = this.preparePlayHead.bind(this);
@@ -323,6 +346,20 @@ class HyperaudioLite {
     this.checkPlayHead = this.checkPlayHead.bind(this);
     this.clearTimer = this.clearTimer.bind(this);
     this.handleSeeked = this.handleSeeked.bind(this);
+  }
+
+  // Throttled deprecation warning — fires at most once per page load
+  // regardless of how many positional-form constructions happen.
+  static _warnPositionalOnce() {
+    if (HyperaudioLite._positionalWarned) return;
+    HyperaudioLite._positionalWarned = true;
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn(
+        'HyperaudioLite: the positional-argument constructor is deprecated. ' +
+        'Pass an options object instead — see the README. The positional form ' +
+        'continues to work across the 2.x line.'
+      );
+    }
   }
 
   // Initialize the HyperaudioLite instance

--- a/multiplayer.html
+++ b/multiplayer.html
@@ -1065,14 +1065,8 @@
   <script src="js/hyperaudio-lite-wrapper.js"></script>
   <script>
 
-  // minimizedMode is still experimental - it aims to show the current words in the title, which can be seen on the browser tab.
-
-  let minimizedMode = false;
-  let autoScroll = true;
-  let doubleClick = false;
-
-  new HyperaudioLite("hypertranscript1", "hyperplayer1", minimizedMode, autoScroll, doubleClick);
-  new HyperaudioLite("hypertranscript2", "hyperplayer2", minimizedMode, autoScroll, doubleClick);
+  new HyperaudioLite({ transcript: "hypertranscript1", player: "hyperplayer1" });
+  new HyperaudioLite({ transcript: "hypertranscript2", player: "hyperplayer2" });
 
   // Coordinate the two players so only one plays at a time.
   const nativeMedia = document.getElementById('hyperplayer1');

--- a/soundcloud.html
+++ b/soundcloud.html
@@ -118,13 +118,7 @@
       <script src="js/hyperaudio-lite.js"></script>
       <script src="js/hyperaudio-lite-extension.js"></script>
       <script>
-      // minimizedMode is still experimental - it aims to show the current words in the title, which can be seen on the browser tab.
-      let minimizedMode = false;
-      let autoScroll = true;
-      let doubleClick = false;
-      let webMonetization = false;
-
-      new HyperaudioLite("hypertranscript", "hyperplayer", minimizedMode, autoScroll, doubleClick, webMonetization);
+      new HyperaudioLite({ transcript: "hypertranscript", player: "hyperplayer" });
       </script>
   </body>
 </html>

--- a/spotify.html
+++ b/spotify.html
@@ -150,13 +150,7 @@
   <script src="js/hyperaudio-lite-extension.js"></script>
 
   <script>
-    // minimizedMode is still experimental - it aims to show the current words in the title, which can be seen on the browser tab.
-    let minimizedMode = false;
-    let autoScroll = true;
-    let doubleClick = false;
-    let webMonetization = false;
-
-    new HyperaudioLite("hypertranscript", "hyperplayer", minimizedMode, autoScroll, doubleClick, webMonetization);
+    new HyperaudioLite({ transcript: "hypertranscript", player: "hyperplayer" });
   </script>
 </body>
 

--- a/videojs.html
+++ b/videojs.html
@@ -1040,13 +1040,7 @@
   <script src="js/hyperaudio-lite.js"></script>
   <script src="js/hyperaudio-lite-extension.js"></script>
   <script>
-    // minimizedMode is still experimental - it aims to show the current words in the title, which can be seen on the browser tab.
-    let minimizedMode = false;
-    let autoScroll = true;
-    let doubleClick = false;
-    let webMonetization = false;
-
-    new HyperaudioLite("hypertranscript", "hyperplayer", minimizedMode, autoScroll, doubleClick, webMonetization);
+    new HyperaudioLite({ transcript: "hypertranscript", player: "hyperplayer" });
   </script>
 </body>
 

--- a/vidstack.html
+++ b/vidstack.html
@@ -1031,13 +1031,7 @@
   <script src="js/hyperaudio-lite-extension.js"></script>
 
   <script>
-    // minimizedMode is still experimental - it aims to show the current words in the title, which can be seen on the browser tab.
-    let minimizedMode = false;
-    let autoScroll = true;
-    let doubleClick = false;
-    let webMonetization = false;
-
-    new HyperaudioLite("hypertranscript", "hyperplayer", minimizedMode, autoScroll, doubleClick, webMonetization);
+    new HyperaudioLite({ transcript: "hypertranscript", player: "hyperplayer" });
   </script>
 </body>
 

--- a/vimeo.html
+++ b/vimeo.html
@@ -292,13 +292,7 @@
   <script src="js/hyperaudio-lite-extension.js"></script>
   <script>
 
-    // minimizedMode is still experimental - it aims to show the current words in the title, which can be seen on the browser tab.
-    let minimizedMode = false;
-    let autoScroll = true;
-    let doubleClick = false;
-    let webMonetization = false;
-
-    new HyperaudioLite("hypertranscript", "hyperplayer", minimizedMode, autoScroll, doubleClick, webMonetization);
+    new HyperaudioLite({ transcript: "hypertranscript", player: "hyperplayer" });
   </script>
 </body>
 

--- a/youtube-multiplayer.html
+++ b/youtube-multiplayer.html
@@ -216,14 +216,8 @@
     <script src="js/hyperaudio-lite-extension.js"></script>
     <script>
 
-      // minimizedMode is still experimental - it aims to show the current words in the title, which can be seen on the browser tab.
-      let minimizedMode = false;
-      let autoScroll = true;
-      let doubleClick = false;
-      let webMonetization = false;
-
-      const hal1 = new HyperaudioLite("hypertranscript1", "hyperplayer1", minimizedMode, autoScroll, doubleClick, webMonetization);
-      const hal2 = new HyperaudioLite("hypertranscript2", "hyperplayer2", minimizedMode, autoScroll, doubleClick, webMonetization);
+      const hal1 = new HyperaudioLite({ transcript: "hypertranscript1", player: "hyperplayer1" });
+      const hal2 = new HyperaudioLite({ transcript: "hypertranscript2", player: "hyperplayer2" });
 
       // Coordinate the two players so only one plays at a time. Piggyback on
       // HAL's own YT.Player wrappers (rather than creating competing ones) and

--- a/youtube.html
+++ b/youtube.html
@@ -213,14 +213,11 @@
     <script src="js/hyperaudio-lite.js"></script>
     <script src="js/hyperaudio-lite-extension.js"></script>
     <script>
-      // minimizedMode is still experimental - it aims to show the current words in the title, which can be seen on the browser tab.
-      let minimizedMode = false;
-      let autoScroll = true;
-      let doubleClick = false;
-      let webMonetization = false;
-      let playOnClick = false;
-
-      new HyperaudioLite("hypertranscript", "hyperplayer", minimizedMode, autoScroll, doubleClick, webMonetization, playOnClick);
+      new HyperaudioLite({
+        transcript: "hypertranscript",
+        player: "hyperplayer",
+        playOnClick: false,
+      });
     </script>
   </body>
 </html>


### PR DESCRIPTION
Part of the 2.5 release scope. Adds an options-object constructor to \`HyperaudioLite\` while preserving the positional-argument form indefinitely across the 2.x line — per the BC commitment logged on #217.

## New API

```javascript
new HyperaudioLite({
  transcript: "hypertranscript",
  player: "hyperplayer",
  autoScroll: true,
  playOnClick: true,
});
```

| Option | Default | Description |
|---|---|---|
| \`transcript\` | _(required)_ | Element id of the transcript container |
| \`player\` | _(required)_ | Element id of the audio/video element |
| \`autoScroll\` | \`true\` | Scroll the transcript to follow playback and seeks |
| \`playOnClick\` | \`true\` | Start playback when the user clicks a word |
| \`doubleClick\` | \`false\` | Require a double-click for word interaction |
| \`minimizedMode\` | \`false\` | Show current word in browser tab title (experimental) |
| \`webMonetization\` | \`false\` | Inject \`<link rel="monetization">\` from \`data-wm\` |

Constructor sniffs the first argument: if it's a plain object, the new form runs; otherwise the legacy positional path runs with a throttled deprecation warning (once per page load).

## Backward compatibility

Per the BC commitment in [issue #217 comment](https://github.com/hyperaudio/hyperaudio-lite/issues/217#issuecomment-4783923278):

- Positional form **keeps working indefinitely** across the 2.x line — not just one release.
- Deprecation warning is **informational** (\`console.warn\`), not coercive. Throttled to once per page load via a static flag, so it can't spam the console regardless of how many instances are created.
- Both call shapes hit the same \`init()\` path — no semantic difference at runtime.
- Defaults applied only on the options-object path so positional callers get **identical** behaviour to today (undefined stays undefined where it was undefined).

## Test plan

- [x] \`npm test\` — 31/31 pass (27 existing kept verbatim + 4 new for the options-object form)
- New tests:
  - \`initialization with options object — all flags explicit\`
  - \`initialization with options object — defaults applied for omitted flags\`
  - \`positional constructor emits a deprecation warning (once)\`
  - \`options-object constructor does NOT emit a deprecation warning\`

## Files touched

- \`js/hyperaudio-lite.js\` — constructor refactor + throttled warning helper
- \`js/hyperaudio-lite.mjs\` — regenerated from .js
- \`__TEST__/hyperaudio-lite.test.js\` — added 4 new tests for the new form
- \`README.md\` — new form shown as primary with an options table; positional documented as deprecated
- All 10 example HTML files migrated to the new form (tighter, more readable)

No version bump — folds into the 2.5.0 release commit.

## Note

A natural follow-up is exposing \`scrollContainer\` and \`scrollOffset\` (#230) as constructor options. That fits cleanly into the same options-object shape and won't need any constructor changes.