### PR TITLE
Add scrollOffset constructor option (refs #230)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ All options:
 | `doubleClick` | `false` | Require a double-click instead of a single click for word interaction |
 | `minimizedMode` | `false` | Show the current word in the browser tab title (experimental) |
 | `webMonetization` | `false` | Inject `<link rel="monetization">` from `data-wm` payment pointers in the transcript |
+| `scrollOffset` | `0` | Pixels to subtract from the autoscroll target (useful when a sticky header overlaps the transcript) |
 
 #### Deprecated positional form
 

--- a/__TEST__/hyperaudio-lite.test.js
+++ b/__TEST__/hyperaudio-lite.test.js
@@ -298,6 +298,46 @@ test("scrollToParagraph updates parentElementIndex", () => {
   expect(ht.parentElementIndex).toBe(1);
 });
 
+test("scrollOffset defaults to 0", () => {
+  const customHt = new HyperaudioLite({ transcript: "hypertranscript", player: "hyperplayer" });
+  expect(customHt.scrollOffset).toBe(0);
+});
+
+test("scrollOffset can be set via options object", () => {
+  const customHt = new HyperaudioLite({
+    transcript: "hypertranscript",
+    player: "hyperplayer",
+    scrollOffset: 80,
+  });
+  expect(customHt.scrollOffset).toBe(80);
+});
+
+test("scrollOffset is subtracted from scrollToParagraph target", () => {
+  // Set up an instance with a non-zero offset, then capture what
+  // smoothScrollTo would be called with. The offset should be subtracted
+  // from targetTop, clamped to >= 0.
+  const customHt = new HyperaudioLite({
+    transcript: "hypertranscript",
+    player: "hyperplayer",
+    scrollOffset: 30,
+  });
+  customHt.autoscroll = true;
+  customHt.parentElementIndex = 0;
+  let captured = null;
+  customHt.smoothScrollTo = (container, targetTop, duration) => {
+    captured = targetTop;
+  };
+  // Compute what an offset-of-zero call would produce, then verify the
+  // offset-aware call lands 30 lower (or 0 if clamping kicks in).
+  const containerRect = customHt.scrollContainer.getBoundingClientRect();
+  const paragraph = customHt.parentElements[1];
+  const paragraphRect = paragraph.getBoundingClientRect();
+  const expectedWithoutOffset = customHt.scrollContainer.scrollTop + (paragraphRect.top - containerRect.top);
+  const expected = Math.max(0, expectedWithoutOffset - 30);
+  customHt.scrollToParagraph(1, 6);
+  expect(captured).toBe(expected);
+});
+
 test("checkPaymentPointer returns correct payment pointer", () => {
   const p1 = document.getElementById('p1');
   expect(ht.checkPaymentPointer(p1)).toBe("payment-pointer");

--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -326,6 +326,7 @@ class HyperaudioLite {
         doubleClick: false,
         webMonetization: false,
         playOnClick: true,
+        scrollOffset: 0,
         ...args[0],
       };
     } else {
@@ -338,6 +339,10 @@ class HyperaudioLite {
 
     this.transcript = document.getElementById(opts.transcript);
     this.init(opts.player, opts.minimizedMode, opts.autoScroll, opts.doubleClick, opts.webMonetization, opts.playOnClick);
+    // scrollOffset is read directly by scrollToParagraph; consumers can also
+    // set/change it on the instance after construction (e.g. for layouts that
+    // resize their sticky header).
+    this.scrollOffset = opts.scrollOffset || 0;
 
     // Ensure correct binding for class methods
     this.preparePlayHead = this.preparePlayHead.bind(this);
@@ -701,8 +706,8 @@ class HyperaudioLite {
         if (currentParagraph) {
           const containerRect = this.scrollContainer.getBoundingClientRect();
           const paragraphRect = currentParagraph.getBoundingClientRect();
-          const targetTop = this.scrollContainer.scrollTop + (paragraphRect.top - containerRect.top);
-          this.smoothScrollTo(this.scrollContainer, targetTop, 800);
+          const targetTop = this.scrollContainer.scrollTop + (paragraphRect.top - containerRect.top) - (this.scrollOffset || 0);
+          this.smoothScrollTo(this.scrollContainer, Math.max(0, targetTop), 800);
         }
       }
       this.parentElementIndex = currentParentElementIndex;

--- a/js/hyperaudio-lite.mjs
+++ b/js/hyperaudio-lite.mjs
@@ -326,6 +326,7 @@ class HyperaudioLite {
         doubleClick: false,
         webMonetization: false,
         playOnClick: true,
+        scrollOffset: 0,
         ...args[0],
       };
     } else {
@@ -338,6 +339,10 @@ class HyperaudioLite {
 
     this.transcript = document.getElementById(opts.transcript);
     this.init(opts.player, opts.minimizedMode, opts.autoScroll, opts.doubleClick, opts.webMonetization, opts.playOnClick);
+    // scrollOffset is read directly by scrollToParagraph; consumers can also
+    // set/change it on the instance after construction (e.g. for layouts that
+    // resize their sticky header).
+    this.scrollOffset = opts.scrollOffset || 0;
 
     // Ensure correct binding for class methods
     this.preparePlayHead = this.preparePlayHead.bind(this);
@@ -701,8 +706,8 @@ class HyperaudioLite {
         if (currentParagraph) {
           const containerRect = this.scrollContainer.getBoundingClientRect();
           const paragraphRect = currentParagraph.getBoundingClientRect();
-          const targetTop = this.scrollContainer.scrollTop + (paragraphRect.top - containerRect.top);
-          this.smoothScrollTo(this.scrollContainer, targetTop, 800);
+          const targetTop = this.scrollContainer.scrollTop + (paragraphRect.top - containerRect.top) - (this.scrollOffset || 0);
+          this.smoothScrollTo(this.scrollContainer, Math.max(0, targetTop), 800);
         }
       }
       this.parentElementIndex = currentParentElementIndex;


### PR DESCRIPTION
Last piece of the 2.5 release scope. Lets consumers with a sticky/overlapping header push the autoscroll landing point down so the active paragraph isn't tucked underneath the header.

## Change

\`scrollToParagraph\` previously scrolled the active paragraph flush to the top of \`scrollContainer\`:

```js
const targetTop = this.scrollContainer.scrollTop + (paragraphRect.top - containerRect.top);
this.smoothScrollTo(this.scrollContainer, targetTop, 800);
```

Now subtracts a configurable offset (clamped to >= 0 so we never produce a negative scroll):

```js
const targetTop = this.scrollContainer.scrollTop + (paragraphRect.top - containerRect.top) - (this.scrollOffset || 0);
this.smoothScrollTo(this.scrollContainer, Math.max(0, targetTop), 800);
```

\`scrollOffset\` is exposed as a constructor option (defaulting to 0), and can also be set on the instance after construction in case the header height changes dynamically.

```javascript
new HyperaudioLite({
  transcript: "hypertranscript",
  player: "hyperplayer",
  scrollOffset: 80,   // clears a 80px sticky header
});
```

The Hyperaudio Lite Editor has been overriding \`scrollToParagraph\` entirely just to apply such an offset — it can drop the override now.

## Compat

- Default \`scrollOffset: 0\` preserves current behaviour exactly.
- Available on both options-object and positional constructor paths (positional doesn't accept the new option but the instance defaults to 0, so existing positional callers see no change).
- All 34 tests pass (31 existing + 3 new).

## Tests

- \`scrollOffset defaults to 0\`
- \`scrollOffset can be set via options object\`
- \`scrollOffset is subtracted from scrollToParagraph target\` — directly stubs \`smoothScrollTo\` to capture \`targetTop\` and asserts the offset was applied with the clamp behaviour.

No version bump — folds into the 2.5.0 release commit.