### PR TITLE
Search: match partial words (#241)

### DIFF
--- a/css/examples.css
+++ b/css/examples.css
@@ -320,6 +320,12 @@ body.is-demo .hyperaudio-transcript .active > .active {
   background: var(--accent-soft);
   border-radius: 2px;
 }
+body.is-demo .hyperaudio-transcript .search-mark {
+  background: var(--accent);
+  color: var(--bg-2);
+  padding: 0 2px;
+  border-radius: 2px;
+}
 body.is-demo #searchForm {
   margin: 0 0 18px;
   font-family: var(--mono);

--- a/css/hyperaudio-lite-player.css
+++ b/css/hyperaudio-lite-player.css
@@ -43,8 +43,11 @@
   color: #777;
 }
 
-.hyperaudio-transcript .search-match {
+.hyperaudio-transcript .search-mark {
   background-color: pink;
+  color: inherit;
+  padding: 0 1px;
+  border-radius: 2px;
 }
 
 .hyperaudio-transcript .share-match {

--- a/demos/index.html
+++ b/demos/index.html
@@ -1037,6 +1037,7 @@
   </div>
   
   <script src="../js/hyperaudio-lite.js"></script>
+  <script src="../js/hyperaudio-lite-extension.js"></script>
   <script src="../js/caption.js"></script>
   <script>
 

--- a/js/hyperaudio-lite-extension.js
+++ b/js/hyperaudio-lite-extension.js
@@ -1,76 +1,57 @@
 /*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
-/*! Version 2.1.1b */
+/*! Version 2.5.1 */
 
 'use strict';
-// Example wrapper for hyperaudio-lite with search and playbackRate included
 
-let searchForm = document.getElementById('searchForm');
+// Example wrapper for hyperaudio-lite with search and playback-rate controls.
+// Highlights every transcript span whose normalised text contains the search
+// phrase. Multi-word phrases walk consecutive spans — each phrase word must be
+// contained by the matching span.
 
-if (searchForm) {
-  searchForm.addEventListener('submit', function(event){
-    searchPhrase(document.getElementById('search').value);
-    event.preventDefault();
-  }, false);
-}
+const SEARCH_PUNCT = /[.,\-\/#!$%\^&\*;:{}=_`~()\?\s]/g;
+const normalise = (text) => text.toLowerCase().replace(SEARCH_PUNCT, '');
 
+const searchPhrase = (phrase) => {
+  const spans = document.querySelectorAll('[data-m]');
+  if (!spans.length) return;
 
-let searchPhrase = function (phrase) {
-	
-  let htmlWords = document.querySelectorAll('[data-m]');
-  let htmlWordsLen = htmlWords.length;
-	
-  let phraseWords = phrase.split(" ");
-  let phraseWordsLen = phraseWords.length;
-  let matchedTimes = [];
+  document.querySelectorAll('.search-match')
+    .forEach((el) => el.classList.remove('search-match'));
 
-  // clear matched times
-  let searchMatched = document.querySelectorAll('.search-match');
+  const needles = phrase
+    .toLowerCase()
+    .split(/\s+/)
+    .map((w) => w.replace(SEARCH_PUNCT, ''))
+    .filter(Boolean);
+  if (!needles.length) return;
 
-  searchMatched.forEach((match) => {
-    match.classList.remove('search-match');
-  });
-
-  for (let i = 0; i < htmlWordsLen; i++) {
-    let numWordsMatched = 0;
-    let potentiallyMatched = [];
-
-    for (let j = 0; j < phraseWordsLen; j++) {
-      let wordIndex = i + numWordsMatched;
-
-      if (wordIndex >= htmlWordsLen) {
-        break;
-      }
-
-      // regex removes punctuation - NB for htmlWords case we also remove the space
-
-      if (phraseWords[j].toLowerCase() == htmlWords[wordIndex].innerHTML.toLowerCase().replace(/[\.,-\/#!$%\^&\*;:{}=\-_`~()\? ]/g,"")) {
-        potentiallyMatched.push(htmlWords[wordIndex].getAttribute('data-m'));
-        numWordsMatched++;
-      } else {
-        break;
-      }
-
-      // if the num of words matched equal the search phrase we have a winner!
-      if (numWordsMatched >= phraseWordsLen) {
-        matchedTimes = matchedTimes.concat(potentiallyMatched);
+  const lastStart = spans.length - needles.length;
+  for (let i = 0; i <= lastStart; i++) {
+    const hit = needles.every((needle, j) =>
+      normalise(spans[i + j].innerHTML).includes(needle)
+    );
+    if (hit) {
+      for (let j = 0; j < needles.length; j++) {
+        spans[i + j].classList.add('search-match');
       }
     }
   }
+};
 
-  // display
-  matchedTimes.forEach(matchedTime => {
-    document.querySelectorAll("[data-m='"+matchedTime+"']")[0].classList.add("search-match");
+document.getElementById('searchForm')?.addEventListener('submit', (event) => {
+  event.preventDefault();
+  searchPhrase(document.getElementById('search').value);
+});
+
+window.addEventListener('load', () => {
+  const pbr = document.getElementById('pbr');
+  const display = document.getElementById('currentPbr');
+  if (!pbr) return;
+
+  pbr.addEventListener('input', () => {
+    if (display) display.textContent = pbr.value;
+    if (typeof hyperplayer !== 'undefined') {
+      hyperplayer.playbackRate = pbr.value;
+    }
   });
-}
-
-window.onload = function() {
-	const playbackRateCtrl = document.getElementById('pbr');
-	const currentPlaybackRate = document.getElementById('currentPbr');
-
-  if (playbackRateCtrl !== null) {
-    playbackRateCtrl.addEventListener('input', function(){
-      currentPlaybackRate.innerHTML = playbackRateCtrl.value;
-      hyperplayer.playbackRate = playbackRateCtrl.value;
-    },false);
-  }
-}
+});

--- a/js/hyperaudio-lite-extension.js
+++ b/js/hyperaudio-lite-extension.js
@@ -4,19 +4,46 @@
 'use strict';
 
 // Example wrapper for hyperaudio-lite with search and playback-rate controls.
-// Highlights every transcript span whose normalised text contains the search
-// phrase. Multi-word phrases walk consecutive spans — each phrase word must be
-// contained by the matching span.
+// Walks consecutive [data-m] spans for multi-word phrases; for each matching
+// span wraps just the matched substring in a <mark class="search-mark"> so the
+// highlight covers the query, not the whole word.
 
 const SEARCH_PUNCT = /[.,\-\/#!$%\^&\*;:{}=_`~()\?\s]/g;
 const normalise = (text) => text.toLowerCase().replace(SEARCH_PUNCT, '');
+
+const clearPreviousSearch = () => {
+  document.querySelectorAll('mark.search-mark').forEach((mark) => {
+    mark.replaceWith(document.createTextNode(mark.textContent));
+  });
+  document.querySelectorAll('.search-match').forEach((el) => {
+    el.classList.remove('search-match');
+    el.normalize(); // merge adjacent text nodes left behind by the unwrap
+  });
+};
+
+// Wrap the first occurrence of `needle` (case-insensitive) inside `span`'s
+// text with <mark class="search-mark">. Punctuation stays outside the mark.
+const highlightSubstring = (span, needle) => {
+  const original = span.textContent;
+  const idx = original.toLowerCase().indexOf(needle);
+  if (idx < 0) return;
+  const before = original.slice(0, idx);
+  const hit = original.slice(idx, idx + needle.length);
+  const after = original.slice(idx + needle.length);
+  span.textContent = '';
+  if (before) span.append(before);
+  const mark = document.createElement('mark');
+  mark.className = 'search-mark';
+  mark.textContent = hit;
+  span.append(mark);
+  if (after) span.append(after);
+};
 
 const searchPhrase = (phrase) => {
   const spans = document.querySelectorAll('[data-m]');
   if (!spans.length) return;
 
-  document.querySelectorAll('.search-match')
-    .forEach((el) => el.classList.remove('search-match'));
+  clearPreviousSearch();
 
   const needles = phrase
     .toLowerCase()
@@ -28,13 +55,14 @@ const searchPhrase = (phrase) => {
   const lastStart = spans.length - needles.length;
   for (let i = 0; i <= lastStart; i++) {
     const hit = needles.every((needle, j) =>
-      normalise(spans[i + j].innerHTML).includes(needle)
+      normalise(spans[i + j].textContent).includes(needle)
     );
-    if (hit) {
-      for (let j = 0; j < needles.length; j++) {
-        spans[i + j].classList.add('search-match');
-      }
-    }
+    if (!hit) continue;
+    needles.forEach((needle, j) => {
+      const span = spans[i + j];
+      span.classList.add('search-match');
+      highlightSubstring(span, needle);
+    });
   }
 };
 


### PR DESCRIPTION
Closes #241.

`searchPhrase()` in `js/hyperaudio-lite-extension.js` now uses `.includes()` on normalised span text, so `fri` finds `Friday` and `test` finds `testing`. Multi-word phrases still walk consecutive spans — each word must be contained by its corresponding span — and every matched span keeps getting the `.search-match` class.

Also modernised the file: `const`/`let`, arrow functions, optional chaining, single source of truth for the punctuation regex.

## Test plan

- [ ] Search `fri` on any demo — `Friday` is highlighted.
- [ ] Single full-word search still matches.
- [ ] `personal data` (two-word) — both spans of the match get highlighted.
- [ ] Empty form is a no-op.
- [ ] `npm test` — 34/34 pass.