### PR TITLE
caption.js: don't let a loadedmetadata listener persist with a stale caption set

### DIFF
--- a/js/caption.js
+++ b/js/caption.js
@@ -1,5 +1,5 @@
 /*! (C) The Hyperaudio Project. MIT @license: en.wikipedia.org/wiki/MIT_License. */
-/*! Version 2.1.5 */
+/*! Version 2.1.6 */
 'use strict';
 
 const caption = function () {
@@ -412,27 +412,39 @@ const caption = function () {
     const video = document.getElementById(playerId);
 
     if (video !== null) {
-      video.addEventListener('loadedmetadata', function listener() {
+      const applyCaptions = function () {
         const track = document.getElementById(`${playerId}-vtt`);
 
         if (track !== null) {
           track.kind = 'captions';
 
           if (label !== undefined) {
-            //console.log("setting label as "+label);
             track.label = label;
           }
 
           if (srclang !== undefined) {
-            //console.log("setting srclang as "+srclang);
             track.srclang = srclang;
           }
 
           track.src = `data:text/vtt,${encodeURIComponent(captionsVtt)}`;
-          video.textTracks[0].mode = 'showing';
-          video.removeEventListener('loadedmetadata', listener, true);
+          if (video.textTracks[0] !== undefined) {
+            video.textTracks[0].mode = 'showing';
+          }
         }
-      }, true);
+      };
+
+      // If the media's metadata has already loaded, 'loadedmetadata' will not
+      // fire again, so apply the captions now; otherwise apply on a single-use
+      // listener. This prevents a listener persisting with a stale captionsVtt
+      // closure and re-applying it when a different media subsequently loads.
+      if (video.readyState >= 1 /* HAVE_METADATA */) {
+        applyCaptions();
+      } else {
+        video.addEventListener('loadedmetadata', function listener() {
+          applyCaptions();
+          video.removeEventListener('loadedmetadata', listener, true);
+        }, true);
+      }
 
       if (video.textTracks !== undefined && video.textTracks[0] !== undefined) {
         video.textTracks[0].mode = 'showing';


### PR DESCRIPTION
Closes #243.

## Problem
`cap.init` attaches a `loadedmetadata` listener to the player to set the caption track. If the media's metadata has already loaded when `cap.init` runs, `loadedmetadata` does not fire again, so the listener never executes and never removes itself — it persists, holding a closure over that invocation's `captionsVtt`. When a different media source later loads into the same player, its `loadedmetadata` triggers the retained listener, which re-applies the previous media's captions in place of the current ones (and repeated `cap.init` calls accumulate further listeners).

Downstream impact: hyperaudio/hyperaudio-lite-editor#356 (previous media's captions persist, occasionally doubled, after loading a new file).

## Fix
Apply the captions immediately when the metadata is already available; otherwise register a single-use listener. No listener persists, so nothing re-applies a stale caption set on a later media change. Bumped `caption.js` to 2.1.6.

## Verification
- Reproduced the original behaviour: after assigning fresh captions and dispatching `loadedmetadata`, the track reverted to the previous VTT.
- With the fix (metadata loaded): captions apply immediately (cues present) and a subsequent `loadedmetadata` no longer overwrites them.
