### PR TITLE
Fix polling after seek during playback

### DIFF
--- a/__TEST__/hyperaudio-lite.test.js
+++ b/__TEST__/hyperaudio-lite.test.js
@@ -432,6 +432,31 @@ test("pausePlayHead clears timer and sets paused to true", () => {
   jest.useRealTimers();
 });
 
+test("handleSeeked reschedules polling while playback continues (regression for #264)", async () => {
+  const inst = new HyperaudioLite({
+    transcript: "hypertranscript",
+    player: "hyperplayer",
+    autoScroll: false,
+  });
+  inst.myPlayer = {
+    paused: false,
+    getTime: jest.fn().mockResolvedValue(3.95),
+  };
+  const clearTimerSpy = jest.spyOn(inst, "clearTimer");
+  const checkStatusSpy = jest.spyOn(inst, "checkStatus").mockImplementation(() => {});
+
+  inst.handleSeeked();
+  await Promise.resolve();
+
+  expect(clearTimerSpy).toHaveBeenCalledTimes(1);
+  expect(checkStatusSpy).toHaveBeenCalledTimes(1);
+  expect(clearTimerSpy.mock.invocationCallOrder[0]).toBeLessThan(
+    checkStatusSpy.mock.invocationCallOrder[0]
+  );
+
+  inst.destroy();
+});
+
 test("share-link hash triggers initial autoscroll (regression for #246)", () => {
   // init() used to run setupInitialPlayHead() while this.autoscroll was still
   // false (setupEventListeners reset it; the real value was applied later by

--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -773,6 +773,10 @@ class HyperaudioLite {
       if (indices.currentWordIndex > 0 && this.autoscroll) {
         this.scrollToParagraph(indices.currentParentElementIndex, indices.currentWordIndex);
       }
+      if (!this.myPlayer.paused) {
+        this.clearTimer();
+        this.checkStatus();
+      }
     })();
   }
 

--- a/js/hyperaudio-lite.mjs
+++ b/js/hyperaudio-lite.mjs
@@ -773,6 +773,10 @@ class HyperaudioLite {
       if (indices.currentWordIndex > 0 && this.autoscroll) {
         this.scrollToParagraph(indices.currentParentElementIndex, indices.currentWordIndex);
       }
+      if (!this.myPlayer.paused) {
+        this.clearTimer();
+        this.checkStatus();
+      }
     })();
   }
 


### PR DESCRIPTION
## Summary
- reschedule transcript polling after a seek while playback is still running
- preserve paused-seek behavior without starting a polling loop
- add a regression test for the stale-timer scenario

## Root cause
`handleSeeked()` updated the visual state but left the timer scheduled from the pre-seek position. Seeking from a long silence into dense speech could therefore leave highlighting frozen until that stale timer fired.

## Validation
- `npm run build`
- `npm test -- --runInBand` (72 tests passed)

Fixes #264