### PR TITLE
Fix native player state when playback is blocked

### DIFF
--- a/__TEST__/hyperaudio-lite.test.js
+++ b/__TEST__/hyperaudio-lite.test.js
@@ -746,6 +746,24 @@ test("registerPlayer() adds a custom player type (#253)", () => {
   delete hyperaudioPlayerOptions.fake;
 });
 
+test("NativePlayer stays paused when browser playback is rejected (#268)", async () => {
+  const inst = new HyperaudioLite({
+    transcript: "hypertranscript",
+    player: "hyperplayer",
+  });
+  const rejectedPlay = Promise.reject(new DOMException("Autoplay blocked", "NotAllowedError"));
+  rejectedPlay.catch(() => {});
+  const playSpy = jest.spyOn(inst.player, "play").mockReturnValue(rejectedPlay);
+
+  inst.myPlayer.paused = true;
+  inst.myPlayer.play();
+  await Promise.resolve();
+
+  expect(inst.myPlayer.paused).toBe(true);
+
+  playSpy.mockRestore();
+  inst.destroy();
+});
 
 
 

--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -62,8 +62,12 @@ class NativePlayer extends BasePlayer {
   }
 
   play() {
-    this.player.play();
-    this.paused = false;
+    const playPromise = this.player.play();
+    if (playPromise && typeof playPromise.catch === 'function') {
+      playPromise.catch(() => {
+        this.paused = true;
+      });
+    }
   }
 
   pause() {

--- a/js/hyperaudio-lite.mjs
+++ b/js/hyperaudio-lite.mjs
@@ -62,8 +62,12 @@ class NativePlayer extends BasePlayer {
   }
 
   play() {
-    this.player.play();
-    this.paused = false;
+    const playPromise = this.player.play();
+    if (playPromise && typeof playPromise.catch === 'function') {
+      playPromise.catch(() => {
+        this.paused = true;
+      });
+    }
   }
 
   pause() {


### PR DESCRIPTION
## Summary

- keep `NativePlayer` paused until the native `play` event confirms playback
- handle rejected `HTMLMediaElement.play()` promises without leaving stale state
- add a regression test for autoplay-policy rejection

## Root cause

`NativePlayer.play()` set its internal `paused` flag to `false` immediately, even when the browser rejected the underlying playback promise. No native `pause` event follows a rejected play attempt, so transcript polling could continue indefinitely against a player that never started.

## Validation

- `npm run build`
- `npm test -- --runInBand` (75 tests passed)
- `git diff --check`

Fixes #268