### PR TITLE
Copy to clipboard: stop replacing apostrophes with backticks

### DIFF
--- a/js/hyperaudio-lite.js
+++ b/js/hyperaudio-lite.js
@@ -478,7 +478,7 @@ class HyperaudioLite {
         const popover = document.getElementById('popover');
 
         if (selection.toString().length > 0) {
-          this.selectionText = selection.toString().replaceAll("'", "`");
+          this.selectionText = selection.toString();
           const range = selection.getRangeAt(0);
           const rect = range.getBoundingClientRect();
 

--- a/js/hyperaudio-lite.mjs
+++ b/js/hyperaudio-lite.mjs
@@ -478,7 +478,7 @@ class HyperaudioLite {
         const popover = document.getElementById('popover');
 
         if (selection.toString().length > 0) {
-          this.selectionText = selection.toString().replaceAll("'", "`");
+          this.selectionText = selection.toString();
           const range = selection.getRangeAt(0);
           const rect = range.getBoundingClientRect();
 


### PR DESCRIPTION
Fixes #280.

`setupPopover()` sanitised the selection with `replaceAll("'", "\`")` before putting it on the clipboard. That escaping is inherited from `js/share-this-clipboard.js`, where it is required because the text is interpolated into an inline `onclick` handler. Here the text only ever reaches `clipboard.writeText()` and `textContent`, both of which take arbitrary strings — so the substitution has no purpose and corrupts every quotation containing an apostrophe.

```diff
-        this.selectionText = selection.toString().replaceAll("'", "`");
+        this.selectionText = selection.toString();
```

Verified by selecting text containing apostrophes and copying: the clipboard and the confirmation dialog now both carry the original characters.